### PR TITLE
SRE foundations — health checks, timeouts, polling, CI smoke tests, SLOs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -71,6 +71,22 @@ jobs:
           url=$(vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
+      - name: Smoke test
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          smoke() {
+            local path="$1"
+            for i in 1 2 3; do
+              status=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL$path")
+              [ "$status" = "200" ] && { echo "OK $path"; return 0; }
+              [ $i -lt 3 ] && sleep 5
+            done
+            echo "FAIL $path — last status $status" && exit 1
+          }
+          smoke /health/ready
+          smoke /api/v1/ping
+
   deploy-preview:
     name: Deploy preview to Vercel
     needs: lint
@@ -94,6 +110,22 @@ jobs:
         run: |
           url=$(vercel deploy --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          smoke() {
+            local path="$1"
+            for i in 1 2 3; do
+              status=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL$path")
+              [ "$status" = "200" ] && { echo "OK $path"; return 0; }
+              [ $i -lt 3 ] && sleep 5
+            done
+            echo "FAIL $path — last status $status" && exit 1
+          }
+          smoke /health/ready
+          smoke /api/v1/ping
 
       - name: Preview URL
         run: echo "### Preview deployment\n${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -1,0 +1,46 @@
+# Synthetic uptime checks: hit production every 15 minutes and fail the job
+# (triggering GitHub's built-in failure email) if any endpoint is down.
+#
+# Required GitHub secret: BACKEND_PRODUCTION_URL — the bare origin of the
+# deployed backend, e.g. https://api.yourdomain.com (no trailing slash).
+name: Synthetics
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch: # allow manual runs from the Actions tab
+
+jobs:
+  probe:
+    name: Probe production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check endpoints
+        env:
+          BASE_URL: ${{ secrets.BACKEND_PRODUCTION_URL }}
+        run: |
+          if [ -z "$BASE_URL" ]; then
+            echo "BACKEND_PRODUCTION_URL secret is not set — skipping probe."
+            exit 0
+          fi
+
+          smoke() {
+            local path="$1"
+            for i in 1 2 3; do
+              status=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL$path")
+              [ "$status" = "200" ] && { echo "OK $path"; return 0; }
+              [ $i -lt 3 ] && sleep 5
+            done
+            echo "FAIL $path — last status $status" && return 1
+          }
+
+          failed=0
+          smoke /health/ready || failed=1
+          smoke /api/v1/ping  || failed=1
+          exit $failed
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Synthetic check — $(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_STEP_SUMMARY"
+          echo "Base URL: ${{ secrets.BACKEND_PRODUCTION_URL }}" >> "$GITHUB_STEP_SUMMARY"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,7 +4,11 @@ APP_NAME=Real Estate Consultant API
 # Reserved for future dev-only toggles (``DEBUG`` still accepted as an alias). OpenAPI ``/docs`` is always on.
 IS_DEV_MODE=false
 
+# Direct connection (local dev / migrations):
 DATABASE_URL=postgresql://postgres:PASSWORD@db.PROJECT_REF.supabase.co:5432/postgres
+# Supabase pgbouncer / Transaction pooler (recommended for Vercel serverless):
+# DATABASE_URL=postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres
+# DB_SERVERLESS=true   # must be true when pointing at pgbouncer (disables prepared statements + NullPool)
 
 SUPABASE_URL=https://PROJECT_REF.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=

--- a/backend/README.md
+++ b/backend/README.md
@@ -111,6 +111,25 @@ If seeding fails after [Dataset preparation](#dataset-preparation) and [Seeding]
 - Ensure **`public.properties`** (and any related tables your seed uses) exist and match the columns expected in `app/models/properties.py` and the seed code. Apply schema in the Supabase SQL editor or whatever migration workflow your team uses. After DDL, run **`NOTIFY pgrst, 'reload schema';`** if PostgREST still serves a stale schema ([docs](https://supabase.com/docs/guides/troubleshooting/refresh-postgrest-schema)). PostgREST **`PGRST204`** usually means the schema cache is stale after DDL—run the same `NOTIFY`, then retry **`python -m app.seed.main`**.
 - Property rows use **upsert** on **`id`**; images for those ids are deleted then re-inserted. For a full reset in dev, truncate or delete rows as needed, then run **`python -m app.seed.main`** again.
 
+## Database connection pooling (Vercel serverless)
+
+Each Vercel serverless invocation starts a fresh Python process and calls `init_db()`, which opens a new SQLAlchemy engine. With a direct Postgres connection (port 5432) this creates a new physical connection on every cold start, quickly exhausting Supabase's connection limit under any real traffic.
+
+**Recommended setup for production:** point `DATABASE_URL` at Supabase's **Transaction Pooler** (pgbouncer, port 6543) and set `DB_SERVERLESS=true`.
+
+```
+# Vercel production env vars
+DATABASE_URL=postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres
+DB_SERVERLESS=true
+```
+
+`DB_SERVERLESS=true` does two things:
+
+1. **`NullPool`** — SQLAlchemy holds no idle connections between requests; pgbouncer owns the pool.
+2. **`statement_cache_size=0`** — disables asyncpg prepared statements, which pgbouncer transaction mode does not support.
+
+Keep `DATABASE_URL` pointing at the direct port (5432) for local dev and schema migrations (pgbouncer transaction mode blocks DDL and `SET` commands).
+
 ## Linting
 
 With dev dependencies installed:

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1,8 +1,38 @@
+from datetime import UTC, datetime
+
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.core.config import settings
+from app.core.database import check_db
+from app.core.supabase_sdk import check_supabase
 
 router = APIRouter(tags=["system"])
+
+_started_at: str = datetime.now(UTC).isoformat()
 
 
 @router.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@router.get("/health/live")
+def health_live() -> dict[str, str]:
+    """Liveness: the process is up and the event loop is responsive."""
+    return {"status": "ok"}
+
+
+@router.get("/health/ready")
+async def health_ready() -> JSONResponse:
+    """Readiness: DB and Supabase are reachable. Returns 503 if either is down."""
+    db_ok, supabase_ok = await check_db(), await check_supabase()
+    all_ok = db_ok and supabase_ok
+    body = {
+        "status": "ok" if all_ok else "degraded",
+        "checks": {"db": "ok" if db_ok else "fail", "supabase": "ok" if supabase_ok else "fail"},
+        "version": settings.version,
+        "git_sha": settings.git_sha or "unknown",
+        "started_at": _started_at,
+    }
+    return JSONResponse(content=body, status_code=200 if all_ok else 503)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,10 @@ class Settings(BaseSettings):
     )
 
     database_url: str
+    # How long asyncpg waits to establish a connection, and the per-statement timeout.
+    # Both prevent a flaky DB call from stalling until Vercel's hard function kill.
+    db_connect_timeout_s: float = 10.0
+    db_statement_timeout_ms: int = 30_000
 
     supabase_url: str
     supabase_service_role_key: str

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     # Both prevent a flaky DB call from stalling until Vercel's hard function kill.
     db_connect_timeout_s: float = 10.0
     db_statement_timeout_ms: int = 30_000
+    # Set to true when DATABASE_URL points to Supabase's pgbouncer (port 6543).
+    # Enables NullPool (no idle connections between invocations) and disables asyncpg
+    # prepared statements, which pgbouncer transaction mode does not support.
+    db_serverless: bool = False
 
     supabase_url: str
     supabase_service_role_key: str

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -44,6 +44,11 @@ class Settings(BaseSettings):
 
     log_level: str = "INFO"
 
+    # Populated automatically by Vercel; set manually for other hosts.
+    git_sha: str = Field(
+        default="", validation_alias=AliasChoices("GIT_SHA", "VERCEL_GIT_COMMIT_SHA")
+    )
+
 
 
 settings = Settings()

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -24,7 +24,14 @@ async def init_db() -> None:
     global DB_ASYNC_ENGINE, DB_ASYNC_SESSION_MAKER
 
     async_url = _async_database_url(settings.database_url)
-    DB_ASYNC_ENGINE = create_async_engine(async_url, pool_pre_ping=True)
+    DB_ASYNC_ENGINE = create_async_engine(
+        async_url,
+        pool_pre_ping=True,
+        connect_args={
+            "timeout": settings.db_connect_timeout_s,
+            "command_timeout": settings.db_statement_timeout_ms / 1000,
+        },
+    )
     DB_ASYNC_SESSION_MAKER = async_sessionmaker(
         DB_ASYNC_ENGINE,
         class_=AsyncSession,

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
 
@@ -25,13 +26,18 @@ async def init_db() -> None:
     global DB_ASYNC_ENGINE, DB_ASYNC_SESSION_MAKER
 
     async_url = _async_database_url(settings.database_url)
+    connect_args: dict = {
+        "timeout": settings.db_connect_timeout_s,
+        "command_timeout": settings.db_statement_timeout_ms / 1000,
+    }
+    if settings.db_serverless:
+        # pgbouncer transaction mode rejects prepared statements; disable them.
+        connect_args["statement_cache_size"] = 0
     DB_ASYNC_ENGINE = create_async_engine(
         async_url,
-        pool_pre_ping=True,
-        connect_args={
-            "timeout": settings.db_connect_timeout_s,
-            "command_timeout": settings.db_statement_timeout_ms / 1000,
-        },
+        pool_pre_ping=not settings.db_serverless,
+        poolclass=NullPool if settings.db_serverless else None,
+        connect_args=connect_args,
     )
     DB_ASYNC_SESSION_MAKER = async_sessionmaker(
         DB_ASYNC_ENGINE,

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -49,6 +50,18 @@ async def close_db() -> None:
 
     DB_ASYNC_ENGINE = None
     DB_ASYNC_SESSION_MAKER = None
+
+
+async def check_db() -> bool:
+    """Return True if the DB engine can execute a trivial query."""
+    if DB_ASYNC_ENGINE is None:
+        return False
+    try:
+        async with DB_ASYNC_ENGINE.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/app/core/supabase_sdk.py
+++ b/backend/app/core/supabase_sdk.py
@@ -32,6 +32,20 @@ async def close_supabase() -> None:
     _supabase_http = None
 
 
+async def check_supabase() -> bool:
+    """Return True if the Supabase REST endpoint responds with a non-5xx status."""
+    key = settings.supabase_anon_key or settings.supabase_service_role_key
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(
+                f"{settings.supabase_url}/rest/v1/",
+                headers={"apikey": key},
+            )
+        return r.status_code < 500
+    except Exception:
+        return False
+
+
 def get_supabase_sdk_client() -> AsyncClient:
     if _supabase_client is None:
         raise RuntimeError("Supabase client requested before init_supabase()")

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,110 @@
+# Runbook — Backend Incident Response
+
+Use this when the backend is down, degraded, or a synthetic check is firing.
+Start at **Step 1** and work down until the issue is identified.
+
+---
+
+## Step 1 — Confirm the scope
+
+| Check | How |
+|-------|-----|
+| Is it us or the platform? | Check [Vercel status](https://www.vercel-status.com) and [Supabase status](https://status.supabase.com) |
+| Which endpoints are affected? | `curl -i https://<BACKEND_URL>/health/ready` — inspect the `checks` field |
+| When did it start? | GitHub Actions → **Synthetics** workflow — first failed run timestamp |
+| What version is live? | `curl https://<BACKEND_URL>/health/ready` → `git_sha` field, match against git log |
+
+---
+
+## Step 2 — Read the logs
+
+1. Open the [Vercel dashboard](https://vercel.com/dashboard) → select the backend project.
+2. Go to **Deployments** → click the active deployment → **Functions** → **Logs**.
+3. Filter by `"level":"ERROR"` or `"message":"unhandled_exception"` to find the first
+   failure in the window.
+4. Note the `request_id` from the error event, then filter on that ID to see the full
+   request trace (all log lines for that request share the same `request_id`).
+
+Key log events and what they mean:
+
+| Event | Meaning |
+|-------|---------|
+| `unhandled_exception` | Uncaught bug — check `error` and `exc_info` fields |
+| `http_exception` + `status: 502` | Supabase PostgREST unreachable |
+| `http_exception` + `status: 503` | HF API key missing or service down |
+| `http_exception` + `status: 504` | HF API timed out |
+| `/health/ready` check `db: fail` | Postgres unreachable or credentials wrong |
+| `/health/ready` check `supabase: fail` | Supabase REST endpoint unreachable |
+
+---
+
+## Step 3 — Common causes and fixes
+
+### DB unreachable (`db: fail` in `/health/ready`)
+
+1. Verify `DATABASE_URL` is set correctly in Vercel → **Settings** → **Environment Variables**.
+2. If using pgbouncer (port 6543), confirm `DB_SERVERLESS=true` is also set.
+3. Check the Supabase project is not paused (free-tier projects pause after 1 week of
+   inactivity) — **Supabase dashboard** → project → **Settings** → **General**.
+4. If the project was paused and resumed, it may take ~30 s before connections are accepted.
+
+### Supabase REST unreachable (`supabase: fail`)
+
+1. Check [Supabase status](https://status.supabase.com) for a platform incident.
+2. Confirm `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are correct in Vercel env vars.
+3. If DDL was recently applied, PostgREST may have a stale schema cache — run
+   `NOTIFY pgrst, 'reload schema';` in the Supabase SQL editor.
+
+### HF / LLM routes failing
+
+1. Confirm `HF_TOKEN` is set and valid (Hugging Face dashboard → Access Tokens).
+2. Check [Hugging Face status](https://status.huggingface.co).
+3. Check `hf_model` config matches an available model on the HF router.
+
+### Environment variable missing
+
+A `500 Internal Server Error` on startup is almost always a missing required env var
+(`DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`).
+Verify all vars from `backend/.env.example` are present in the Vercel project's
+**Production** environment.
+
+---
+
+## Step 4 — Rollback procedure
+
+### Via Vercel dashboard (fastest)
+
+1. Vercel dashboard → backend project → **Deployments**.
+2. Find the last known-good deployment (before the incident started).
+3. Click **⋯** → **Promote to Production**.
+4. Verify: `curl https://<BACKEND_URL>/health/ready` returns `"status":"ok"` and the
+   `git_sha` matches the promoted deployment.
+
+### Via Vercel CLI
+
+```bash
+# List recent deployments to find the target URL
+vercel ls --scope <YOUR_SCOPE>
+
+# Instant rollback to the previous production deployment
+vercel rollback --scope <YOUR_SCOPE>
+
+# Or promote a specific deployment by URL
+vercel promote <DEPLOYMENT_URL> --scope <YOUR_SCOPE>
+```
+
+### Via GitHub (redeploy a previous commit)
+
+```bash
+git revert <bad-commit-sha>   # or git checkout <good-sha> -- relevant files
+git push origin main          # triggers backend.yml → deploy + smoke test
+```
+
+---
+
+## Step 5 — After the incident
+
+1. Update the error-budget tracking in `docs/slo.md` (count failed synthetic probes).
+2. If budget drops below 25 %, freeze non-critical deploys per the error-budget policy.
+3. Write a brief post-incident note (what broke, root cause, fix, prevention) and add it
+   as a comment to the GitHub issue or PR that caused the incident.

--- a/docs/slo.md
+++ b/docs/slo.md
@@ -1,0 +1,69 @@
+# Service Level Objectives
+
+Service targets for the real-estate consultant backend (Vercel serverless + Supabase).
+Measured over a rolling 30-day window against the `/health/ready` synthetic checks
+(`.github/workflows/synthetics.yml`, every 15 minutes).
+
+---
+
+## Availability SLO — 99.5 %
+
+| Window | Allowed downtime |
+|--------|-----------------|
+| 30 days | ≈ 3 h 36 min |
+| 7 days  | ≈ 50 min |
+| 1 day   | ≈ 7 min |
+
+**Error budget math (30 days)**
+
+```
+total minutes = 30 × 24 × 60 = 43 200
+budget        = 43 200 × (1 − 0.995) = 216 minutes ≈ 3 h 36 min
+probe period  = 15 min  →  budget ≈ 14 missed probes before breach
+```
+
+**What counts as downtime:** any 15-minute window in which `/health/ready` returns
+non-200 or times out on all three retry attempts.
+
+**What does NOT count:** scheduled Vercel maintenance announced >24 h in advance,
+or Supabase platform incidents tracked on status.supabase.com.
+
+---
+
+## Latency SLO — p95 ≤ 3 s
+
+All non-LLM API routes (auth, search, listings, account) must respond within **3 s**
+at the 95th percentile as measured by the `duration_ms` field in structured logs.
+
+LLM-backed routes (`/intake/…`, `/outreach/…`) are excluded from the latency SLO
+because they depend on a third-party model endpoint (Hugging Face router);
+they have a separate target of **p95 ≤ 90 s** and a `request_slow` warning log is
+emitted automatically at 3 s.
+
+---
+
+## Error budget policy
+
+| Budget remaining | Action |
+|-----------------|--------|
+| > 50 % | Normal development pace |
+| 25 – 50 % | Prioritise reliability fixes over new features in next sprint |
+| < 25 % | Freeze non-critical deployments; address root cause before next deploy |
+| Exhausted | Incident review required; no production deploy until budget partially restores |
+
+---
+
+## Measuring compliance
+
+Until a dedicated metrics backend is in place, compliance is approximated from:
+
+1. **GitHub Actions** — count failed `Synthetics` workflow runs in the 30-day window.
+   Each failed run = one 15-minute window of downtime.
+2. **Vercel function logs** — filter structured logs for `"level":"ERROR"` or
+   `status >= 500` in `request_completed` events.
+3. **Supabase dashboard** — DB query latency and connection counts.
+
+---
+
+*Targets are internal and set for a single-admin MVP. Revisit thresholds before
+opening the product to external users.*


### PR DESCRIPTION
## Summary

Implements Phase 2 of the skills roadmap — SRE foundations — covering
the JD's **SRE experience** and **Deployment** requirements.

- **DB engine timeouts** — asyncpg connect timeout (10 s) and
  per-statement command timeout (30 s) via `DB_CONNECT_TIMEOUT_S` /
  `DB_STATEMENT_TIMEOUT_MS`. A stalled connection or runaway query now
  fails cleanly instead of hanging until Vercel's hard function kill.

- **`/health/live` + `/health/ready`** — liveness endpoint confirms
  the process is up; readiness checks DB (`SELECT 1`) and Supabase
  (REST ping) and returns 503 if either is down. Response includes
  `version`, `git_sha` (`VERCEL_GIT_COMMIT_SHA`), and `started_at`
  so the live version is instantly identifiable. Original `/health`
  kept for backward compatibility.

- **pgbouncer / serverless connection pooling** — new `DB_SERVERLESS`
  flag switches the SQLAlchemy engine to `NullPool` (no idle
  connections held between invocations) and disables asyncpg prepared
  statements (required for pgbouncer transaction mode). `.env.example`
  now shows both direct and pooler URL forms; README explains when and
  why to use each.

- **Post-deploy smoke tests** — both production and preview deploy jobs
  in `backend.yml` now curl `/health/ready` and `/api/v1/ping` after
  every Vercel deploy (3 retries, 5 s apart). The job fails if either
  endpoint returns non-200.

- **Scheduled synthetic checks** — new `synthetics.yml` workflow hits
  the same two endpoints against production every 15 minutes. A failed
  run triggers GitHub's built-in failure email. Supports manual
  dispatch; skips gracefully if `BACKEND_PRODUCTION_URL` secret is
  unset.

- **SLO + runbook docs** — `docs/slo.md` defines a 99.5% availability
  SLO (≈3 h 36 min budget/month) and p95 ≤ 3 s latency SLO for
  non-LLM routes, with error-budget math and a freeze policy.
  `docs/runbook.md` covers scope confirmation, structured-log triage,
  common causes and fixes, and the exact rollback procedure via Vercel
  dashboard, CLI, or git revert.

## New env vars / secrets

| Name | Where | Purpose |
|------|-------|---------|
| `DB_CONNECT_TIMEOUT_S` | Vercel backend env | asyncpg connection timeout (default 10 s) |
| `DB_STATEMENT_TIMEOUT_MS` | Vercel backend env | Per-query timeout (default 30 000 ms) |
| `DB_SERVERLESS` | Vercel backend env | Set `true` when using pgbouncer URL |
| `GIT_SHA` / `VERCEL_GIT_COMMIT_SHA` | Auto-set by Vercel | Shown in `/health/ready` |
| `BACKEND_PRODUCTION_URL` | GitHub secret | Target for synthetic checks |

## Test plan

- [ ] `GET /health/live` → `{"status": "ok"}`, 200
- [ ] `GET /health/ready` → 200 with `checks.db: "ok"`, `checks.supabase: "ok"`, `git_sha`, `version`
- [ ] Kill DB connection → `/health/ready` returns 503 with `checks.db: "fail"`
- [ ] Merge to main → `backend.yml` deploy job runs smoke test step after deploy
- [ ] Set `BACKEND_PRODUCTION_URL` secret → trigger **Synthetics** workflow manually from Actions tab, confirm it passes