### PR TITLE
Deploy the ingestion microservice to Vercel

### DIFF
--- a/.github/workflows/ingestion-cron.yml
+++ b/.github/workflows/ingestion-cron.yml
@@ -1,0 +1,45 @@
+# Polls the ingestion service's job queue every 15 minutes.
+#
+# Vercel's Hobby plan limits cron jobs to once/day, so this GitHub Actions
+# schedule replaces the */15 Vercel cron as the fallback poller described in
+# docs/architecture.md §6 (primary trigger is the backend's wake_processor()
+# call right after enqueueing; this catches anything that call missed).
+#
+# Required GitHub secrets:
+#   INGESTION_SERVICE_URL        — deployed ingestion service base URL (production)
+#   INGESTION_CRON_TOKEN         — must match the ingestion service's CRON_SECRET
+#   VERCEL_AUTOMATION_BYPASS_SECRET — only if Vercel deployment protection is enabled
+name: Ingestion job poller
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch: # allow manual runs from the Actions tab
+
+jobs:
+  process:
+    name: Process next job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call /api/v1/jobs/process
+        env:
+          BASE_URL: ${{ secrets.INGESTION_SERVICE_URL }}
+          TOKEN: ${{ secrets.INGESTION_CRON_TOKEN }}
+          BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          if [ -z "$BASE_URL" ]; then
+            echo "INGESTION_SERVICE_URL secret is not set — skipping."
+            exit 0
+          fi
+
+          body=$(curl -s -w "\n%{http_code}" \
+            -X POST "$BASE_URL/api/v1/jobs/process" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "x-vercel-protection-bypass: $BYPASS_SECRET")
+          status=$(echo "$body" | tail -1)
+          echo "$body" | head -n -1
+
+          if [ "$status" != "200" ]; then
+            echo "::error::jobs/process returned status $status"
+            exit 1
+          fi

--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -1,0 +1,169 @@
+# Ingestion microservice: lint + tests on PR/push; preview deploy on PR; production deploy on push to main.
+#
+# Separate Vercel project with Root Directory = services/ingestion (Settings → General).
+# Deploy runs from services/ingestion/ (repo-root .vercelignore excludes it for the
+# frontend project; backend/vercelignore excludes it for the backend project).
+#
+# GitHub secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_INGESTION_PROJECT_ID,
+#                 VERCEL_AUTOMATION_BYPASS_SECRET (Vercel → Settings → Deployment Protection)
+# Production env in Vercel: see services/ingestion/.env.example
+name: Ingestion
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/ingestion/**"
+      - ".github/workflows/ingestion.yml"
+  pull_request:
+    paths:
+      - "services/ingestion/**"
+      - ".github/workflows/ingestion.yml"
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_INGESTION_PROJECT_ID }}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/ingestion
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install -U pip && python -m pip install -e ".[dev]"
+
+      - name: Ruff
+        run: ruff check app
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/ingestion
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install -U pip && python -m pip install -e ".[dev]"
+
+      - name: Pytest
+        run: pytest -q
+
+  deploy:
+    name: Deploy to Vercel
+    needs: [lint, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/ingestion
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+          BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          smoke() {
+            local path="$1"
+            for i in 1 2 3; do
+              body=$(curl -s -w "\n%{http_code}" \
+                -H "x-vercel-protection-bypass: $BYPASS_SECRET" \
+                "$BASE_URL$path")
+              status=$(echo "$body" | tail -1)
+              [ "$status" = "200" ] && { echo "OK $path"; return 0; }
+              [ $i -lt 3 ] && sleep 5
+            done
+            echo "FAIL $path — status $status — body:"
+            echo "$body" | head -5
+            exit 1
+          }
+          smoke /health/live
+          smoke /health/ready
+
+  deploy-preview:
+    name: Deploy preview to Vercel
+    needs: [lint, test]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/ingestion
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy preview to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --yes --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+          BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          if [ -z "$BYPASS_SECRET" ]; then
+            echo "::warning::VERCEL_AUTOMATION_BYPASS_SECRET is not set — requests may be blocked by Vercel protection (401)."
+          fi
+          smoke() {
+            local path="$1"
+            for i in 1 2 3; do
+              body=$(curl -s -w "\n%{http_code}" \
+                -H "x-vercel-protection-bypass: $BYPASS_SECRET" \
+                "$BASE_URL$path")
+              status=$(echo "$body" | tail -1)
+              [ "$status" = "200" ] && { echo "OK $path"; return 0; }
+              [ $i -lt 3 ] && sleep 5
+            done
+            echo "FAIL $path — status $status — body:"
+            echo "$body" | head -5
+            exit 1
+          }
+          smoke /health/live
+          smoke /health/ready
+
+      - name: Preview URL
+        run: echo "### Preview deployment\n${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/backend/app/api/v1/endpoints/admin/router.py
+++ b/backend/app/api/v1/endpoints/admin/router.py
@@ -35,8 +35,8 @@ async def enqueue_ingest(
 ) -> EnqueueResponse:
     """Insert a pending job into the queue; returns immediately with job_id.
 
-    The ingestion service polls the queue every 15 minutes via Vercel cron
-    and calls claim_next_job() to atomically pick it up.
+    A GitHub Actions poller calls the ingestion service every 15 minutes,
+    which calls claim_next_job() to atomically pick it up.
     """
     source = body.source
     idem_key = f"{source}:{date.today().isoformat()}"

--- a/backend/app/services/ingestion_client.py
+++ b/backend/app/services/ingestion_client.py
@@ -16,8 +16,8 @@ async def wake_processor() -> None:
     """Best-effort call to process the job queue immediately.
 
     If this fails (service down, auth not configured yet), the job stays
-    queued and is picked up by the ingestion service's Vercel cron within
-    15 minutes, so failures here are logged and swallowed.
+    queued and is picked up by the GitHub Actions job poller within 15
+    minutes, so failures here are logged and swallowed.
     """
     if not settings.ingestion_service_url:
         return

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,7 +295,7 @@ flowchart TD
   C --> D[Frontend subscribes\nSupabase Realtime on jobs row\nadmin-only RLS policy]
 
   W --> F{claim_next_job\nFOR UPDATE SKIP LOCKED}
-  E[Vercel cron, every 15 min\nfallback if the wake call fails] --> F
+  E[GitHub Actions poller, every 15 min\nfallback if the wake call fails] --> F
   F -->|status = pending -> running| D
   F --> G[Run connector\ne.g. loopnet-seed]
   G --> H[Normalize listings]

--- a/services/ingestion/.env.example
+++ b/services/ingestion/.env.example
@@ -8,8 +8,9 @@ DATASET_PATH=dataset/raw-data.json
 
 LOG_LEVEL=INFO
 
-# Vercel sets Authorization: Bearer <CRON_SECRET> on cron requests.
-# Set this to the same value as your Vercel project's CRON_SECRET env var.
+# Shared secret for the GitHub Actions job poller (.github/workflows/ingestion-cron.yml),
+# sent as Authorization: Bearer <CRON_SECRET> every 15 minutes.
+# Set this to the same value as the INGESTION_CRON_TOKEN GitHub secret.
 CRON_SECRET=
 
 # Shared secret the backend sends as Authorization: Bearer <SERVICE_AUTH_TOKEN>

--- a/services/ingestion/app/api/jobs.py
+++ b/services/ingestion/app/api/jobs.py
@@ -40,8 +40,8 @@ class ProcessResponse(BaseModel):
 async def process_next_job() -> ProcessResponse:
     """Claim one pending job, run its connector, and update status to done/failed.
 
-    Called by Vercel cron every 15 minutes, or by the backend to process the
-    queue immediately after enqueueing (see require_internal_token).
+    Called by the GitHub Actions job poller every 15 minutes, or by the backend
+    to process the queue immediately after enqueueing (see require_internal_token).
     """
     client = await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
     try:

--- a/services/ingestion/app/core/auth.py
+++ b/services/ingestion/app/core/auth.py
@@ -32,7 +32,7 @@ def require_service_token(request: Request) -> None:
 
 
 def require_internal_token(request: Request) -> None:
-    """Require the cron secret (Vercel cron) or the service token (backend).
+    """Require the cron secret (GitHub Actions poller) or the service token (backend).
 
     For endpoints called by both internal callers.
     """

--- a/services/ingestion/app/core/config.py
+++ b/services/ingestion/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
 
     log_level: str = "INFO"
 
-    # Set to the CRON_SECRET Vercel injects on cron requests (leave empty to skip auth).
+    # Shared secret for the GitHub Actions job poller (leave empty to skip auth).
     cron_secret: str = ""
 
     # Shared bearer token the backend sends when calling this service directly.

--- a/services/ingestion/openapi.json
+++ b/services/ingestion/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Real Estate Ingestion Service",
+    "title": "Real Estate Consultant API",
     "version": "0.1.0"
   },
   "paths": {
@@ -96,7 +96,7 @@
           "jobs"
         ],
         "summary": "Process Next Job",
-        "description": "Claim one pending job, run its connector, and update status to done/failed.\n\nCalled by Vercel cron every 15 minutes, or by the backend to process the\nqueue immediately after enqueueing (see require_internal_token).",
+        "description": "Claim one pending job, run its connector, and update status to done/failed.\n\nCalled by the GitHub Actions job poller every 15 minutes, or by the backend\nto process the queue immediately after enqueueing (see require_internal_token).",
         "operationId": "process_next_job_api_v1_jobs_process_post",
         "responses": {
           "200": {

--- a/services/ingestion/vercel.json
+++ b/services/ingestion/vercel.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "functions": {
-    "api/**/*.py": {
-      "excludeFiles": "{dataset/**,**/*.pyc,__pycache__/**,.venv/**}"
-    }
-  },
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index" }
   ]

--- a/services/ingestion/vercel.json
+++ b/services/ingestion/vercel.json
@@ -7,11 +7,5 @@
   },
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index" }
-  ],
-  "crons": [
-    {
-      "path": "/api/v1/jobs/process",
-      "schedule": "*/15 * * * *"
-    }
   ]
 }


### PR DESCRIPTION
## Summary
Adds the missing CI/CD pipeline for `services/ingestion` (built in #58 but
never deployed), and fixes the Vercel build/cron setup along the way.

- **Deploy pipeline** (`.github/workflows/ingestion.yml`): lint, pytest,
  preview deploy on PRs, production deploy on push to `main` — mirrors
  `backend.yml`'s structure for a separate Vercel project
  (Root Directory = `services/ingestion`).
- **Job queue poller** (`.github/workflows/ingestion-cron.yml`): replaces
  the `*/15 * * * *` Vercel cron, which Vercel's Hobby plan only honors
  once/day. This workflow polls `POST /api/v1/jobs/process` every 15
  minutes as the fallback path described in `docs/architecture.md` §6
  (primary trigger is the backend's `wake_processor()` call).
- **Vercel build fixes**: removed an empty `api/__init__.py` that prevented
  Vercel's Python builder from discovering `api/index.py`, and dropped the
  now-dead `functions.excludeFiles` config (copy-pasted from
  `backend/vercel.json`, but `services/ingestion` has no `dataset/`/`scripts/`
  to exclude).

## Test plan
- [ ] `services/ingestion`: `ruff check app` and `pytest -q` pass in CI
- [ ] Production deploy succeeds; `/health/live` and `/health/ready` smoke
      tests pass
- [ ] Manually trigger `ingestion-cron.yml` (`workflow_dispatch`) and
      confirm `200` from `/api/v1/jobs/process`
- [ ] `/admin/ingest` end-to-end: enqueue → Realtime status updates →
      `done`