### PR TITLE
Run Vercel CLI from repo root in ingestion deploy workflow

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -72,9 +72,6 @@ jobs:
     needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: services/ingestion
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}
@@ -121,9 +118,6 @@ jobs:
     needs: [lint, test]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: services/ingestion
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The ingestion deploy workflow ran `vercel pull` / `vercel deploy` from
  `working-directory: services/ingestion`. The Vercel project has
  Root Directory = `services/ingestion` set in the dashboard, so the CLI
  appended that to the CWD, producing
  `…/services/ingestion/services/ingestion` — a path that doesn't exist.
- Removed the `defaults.run.working-directory` from the `deploy` and
  `deploy-preview` jobs so Vercel CLI runs from the repo root, where
  `services/ingestion` resolves correctly (same pattern as `backend.yml`).
- `lint` and `test` jobs are unchanged — they still run from
  `services/ingestion`.

## Test plan
- [ ] Push to a PR targeting `main` with a `services/ingestion/**` change
- [ ] `deploy-preview` job completes without the
      "path does not exist" error
- [ ] Smoke tests (`/health/live`, `/health/ready`) pass on the preview URL