### PR TITLE
Resolve ingestion contract-check drift and add manual workflow triggers

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,6 +9,7 @@
 name: Backend
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -10,6 +10,7 @@
 name: Ingestion
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/services/ingestion/openapi.json
+++ b/services/ingestion/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Real Estate Consultant API",
+    "title": "Real Estate Ingestion Service",
     "version": "0.1.0"
   },
   "paths": {


### PR DESCRIPTION

## Summary

Fixes the failing `contract-check` job and adds `workflow_dispatch` so both
CI workflows can be run on demand.

## Changes

### Fix contract-check drift
`services/ingestion/openapi.json` had the title `Real Estate Consultant API`,
which was captured from a local `.env` `APP_NAME` override when the schema was
last generated. CI regenerates the client without that `.env` and uses the
default `app_name` (`Real Estate Ingestion Service`), so the committed schema
drifted and failed:

Error: Ingestion API contract changed — run
'python scripts/generate_ingestion_client.py' and commit the result.

Regenerated the schema with the default app name; the diff is a single title
line and `models.py` is unchanged.

### Add workflow_dispatch
Added `workflow_dispatch:` to `backend.yml` and `ingestion.yml` so either
workflow can be triggered manually from the Actions tab on any branch.