### PR TITLE
Add community guidelines and contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a bug in the app, backend, or frontend
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (Next.js)
+        - Backend (FastAPI)
+        - Ingestion / connectors
+        - Supabase / data
+        - Deployment / CI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: Browser/OS, local vs. deployed, relevant env vars (no secrets)
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/radcrew/real-estate-consultant/security/policy
+    about: Please do not report security vulnerabilities as public issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an idea or enhancement for the project
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow or pain point this addresses (intake, ingestion, ranking, outreach, etc.).
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (Next.js)
+        - Backend (FastAPI)
+        - Ingestion / connectors
+        - Supabase / data
+        - Deployment / CI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- Closes #123, or "N/A" -->
+
+## Area
+
+- [ ] Frontend (Next.js)
+- [ ] Backend (FastAPI)
+- [ ] Ingestion / connectors
+- [ ] Supabase / data
+- [ ] Deployment / CI
+- [ ] Docs
+
+## How was this tested?
+
+<!-- Commands run, manual steps, screenshots if UI-facing -->
+
+## Checklist
+
+- [ ] Lint passes (`ruff check .` for backend, `npm run lint` for frontend)
+- [ ] Tests pass (`pytest` for backend, `npm run test` for frontend) and were added/updated for the change
+- [ ] No secrets or credentials committed
+- [ ] Docs updated if behavior or setup changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior deemed inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, discussions, and any other project communication channels), and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at **code@radcrew.org**. All complaints will be reviewed and investigated promptly and fairly.
+
+Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for helping build the real estate consultant MVP. This project follows the [Code of Conduct](CODE_OF_CONDUCT.md) — please read it before contributing.
+
+## Getting set up
+
+- **Backend (FastAPI):** from `backend/`, run `pip install -e ".[dev]"`, then start the API with `fastapi dev` (or `fastapi dev backend/app/main.py` from the repo root).
+- **Frontend (Next.js):** from `frontend/`, copy `.env.example` to `.env.local`, then `npm install` and `npm run dev`.
+
+See [README.md](README.md) for full local setup and deployment details.
+
+## Workflow
+
+1. Create a branch off `main` for your change (e.g. `feat/short-description`, `fix/short-description`).
+2. Keep changes focused — small, reviewable commits and pull requests are strongly preferred over large ones.
+3. Write a clear commit message describing *why* the change was made, not just what changed.
+4. Open a pull request against `main` using the [PR template](.github/PULL_REQUEST_TEMPLATE.md). Link any related issue.
+5. Make sure CI is green before requesting review.
+
+## Code style & checks
+
+- **Backend:** lint with `ruff` (`ruff check .` from `backend/`); tests run with `pytest` (`pytest` from `backend/`, coverage via `pytest-cov`).
+- **Frontend:** lint with `npm run lint`; tests run with `npm run test` (Vitest), coverage via `npm run test:coverage`.
+
+Run the relevant checks locally before opening a PR — the same checks run in CI (`.github/workflows/backend.yml`, `.github/workflows/frontend.yml`, `.github/workflows/coverage.yml`).
+
+## Reporting bugs & requesting features
+
+Use the [issue templates](.github/ISSUE_TEMPLATE) to file bug reports or feature requests. For security vulnerabilities, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
+
+## Questions
+
+If anything here is unclear, open an issue or reach out at code@radcrew.org.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Radcrew
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it privately — **do not open a public GitHub issue**.
+
+Email **code@radcrew.org** with:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (proof-of-concept code or requests, if applicable)
+- Any relevant logs, screenshots, or affected endpoints/files
+
+We will acknowledge your report within **3 business days** and aim to provide a status update (triage result, expected fix timeline) within **7 business days**.
+
+## Scope
+
+This covers the `real-estate-consultant` application: the FastAPI backend, the Next.js frontend, and their Supabase/OpenRouter integrations as configured in this repository. Third-party services we depend on (Supabase, OpenRouter, Vercel, Apify, etc.) should be reported directly to those vendors.
+
+## Supported Versions
+
+This is an actively developed internal MVP tracked on `main`. Only the latest state of `main` is supported; there are no maintained release branches.
+
+## Disclosure
+
+Please give us a reasonable amount of time to investigate and remediate a report before disclosing it publicly. We'll credit reporters who wish to be credited once a fix ships.


### PR DESCRIPTION
## Summary
Adds the standard community/governance docs needed for open-source contribution: license, code of conduct, security policy, contributing guide, and issue/PR templates.

- Add MIT license
- Add issue templates (bug report, feature request) and PR template
- Add Contributor Covenant code of conduct
- Add security policy (SECURITY.md)
- Add contributing guide (CONTRIBUTING.md)