### PR TITLE
Account password 404, redundant profile fetch, and dropdown close bug

### DIFF
--- a/backend/app/api/v1/endpoints/account/password.py
+++ b/backend/app/api/v1/endpoints/account/password.py
@@ -14,7 +14,7 @@ from app.repositories.account import (
 )
 from app.schemas.account import AccountPasswordChangeRequest
 
-router = APIRouter(prefix="/account", tags=["account"])
+router = APIRouter(tags=["account"])
 
 @router.post("/password", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
 async def change_account_password(

--- a/backend/app/api/v1/endpoints/account/profile.py
+++ b/backend/app/api/v1/endpoints/account/profile.py
@@ -33,11 +33,13 @@ async def get_account_profile(
     current_user: CurrentUser,
     client: SupabaseSdkDep,
 ) -> AccountProfileResponse:
+    """``current_user`` already comes from a live token check, so no need to
+    re-fetch it via the Admin API here (that's only required after PATCH
+    mutates auth user attributes)."""
     user_id = UUID(current_user.id)
 
-    user = await get_auth_user(client, current_user.id)
     raw = await get_profile_row(client, user_id)
-    return account_profile_response(user=user, profile=profile_from_row(raw))
+    return account_profile_response(user=current_user, profile=profile_from_row(raw))
 
 
 @router.patch("/profile", response_model=AccountProfileResponse)

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -30,6 +30,7 @@ def mock_user():
     user = MagicMock()
     user.id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     user.email = "user@example.com"
+    user.phone = None
     return user
 
 

--- a/backend/tests/api/test_account.py
+++ b/backend/tests/api/test_account.py
@@ -99,7 +99,7 @@ class TestChangePassword:
             patch("app.api.v1.endpoints.account.password.update_auth_user_password", new_callable=AsyncMock),
         ):
             r = await client.post(
-                "/api/v1/account/account/password",
+                "/api/v1/account/password",
                 json={"current_password": "oldpass1", "new_password": "newpass1"},
             )
         assert r.status_code == 204
@@ -107,7 +107,7 @@ class TestChangePassword:
     async def test_same_password_returns_422(self, client, mock_user):
         mock_user.email = "user@example.com"
         r = await client.post(
-            "/api/v1/account/account/password",
+            "/api/v1/account/password",
             json={"current_password": "samepass", "new_password": "samepass"},
         )
         assert r.status_code == 422
@@ -115,7 +115,7 @@ class TestChangePassword:
     async def test_no_email_returns_400(self, client, mock_user):
         mock_user.email = ""
         r = await client.post(
-            "/api/v1/account/account/password",
+            "/api/v1/account/password",
             json={"current_password": "oldpass1", "new_password": "newpass1"},
         )
         assert r.status_code == 400

--- a/backend/tests/api/test_account.py
+++ b/backend/tests/api/test_account.py
@@ -24,19 +24,11 @@ def _make_auth_user(email: str = "user@example.com"):
 
 
 class TestGetAccountProfile:
-    async def test_returns_profile(self, client):
-        auth_user = _make_auth_user()
-        with (
-            patch(
-                "app.api.v1.endpoints.account.profile.get_auth_user",
-                new_callable=AsyncMock,
-                return_value=auth_user,
-            ),
-            patch(
-                "app.api.v1.endpoints.account.profile.get_profile_row",
-                new_callable=AsyncMock,
-                return_value={"id": _UID, "first_name": "Alice", "last_name": "Smith"},
-            ),
+    async def test_returns_profile(self, client, mock_user):
+        with patch(
+            "app.api.v1.endpoints.account.profile.get_profile_row",
+            new_callable=AsyncMock,
+            return_value={"id": _UID, "first_name": "Alice", "last_name": "Smith"},
         ):
             r = await client.get("/api/v1/account/profile")
         assert r.status_code == 200
@@ -45,13 +37,23 @@ class TestGetAccountProfile:
         assert body["first_name"] == "Alice"
 
     async def test_profile_row_none_returns_minimal(self, client):
-        auth_user = _make_auth_user()
+        with patch(
+            "app.api.v1.endpoints.account.profile.get_profile_row",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            r = await client.get("/api/v1/account/profile")
+        assert r.status_code == 200
+        assert r.json()["first_name"] is None
+
+    async def test_does_not_call_admin_api(self, client):
+        """GET must not re-fetch the auth user via the Admin API — that call is a
+        redundant network round-trip and was the source of intermittent 503s."""
         with (
             patch(
                 "app.api.v1.endpoints.account.profile.get_auth_user",
                 new_callable=AsyncMock,
-                return_value=auth_user,
-            ),
+            ) as mock_get_auth_user,
             patch(
                 "app.api.v1.endpoints.account.profile.get_profile_row",
                 new_callable=AsyncMock,
@@ -60,7 +62,7 @@ class TestGetAccountProfile:
         ):
             r = await client.get("/api/v1/account/profile")
         assert r.status_code == 200
-        assert r.json()["first_name"] is None
+        mock_get_auth_user.assert_not_called()
 
 
 class TestUpdateAccountProfile:

--- a/frontend/components/landing/header/auth-nav/dropdown.tsx
+++ b/frontend/components/landing/header/auth-nav/dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment } from "react";
+import { Fragment, useEffect, useRef, type RefObject } from "react";
 import { Popover, Transition } from "@headlessui/react";
 import { Heart, LogOut, UserRound } from "lucide-react";
 import Link from "next/link";
@@ -20,8 +20,38 @@ const ITEM_CLASS =
 const ICON_WRAP =
   "flex flex-shrink-0 items-center justify-center text-neutral-500 dark:text-neutral-300";
 
+/**
+ * Headless UI's Popover is supposed to close on outside click on its own,
+ * but that only fires reliably when the click lands on a focusable/loosely
+ * focusable element. Plain clicks on inert page content (empty divs, text)
+ * were leaving the panel open, so we close it explicitly here instead of
+ * relying on that internal detection.
+ */
+const CloseOnOutsideClick = ({
+  containerRef,
+  close,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>;
+  close: () => void;
+}) => {
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [containerRef, close]);
+
+  return null;
+};
+
 export const ProfileDropdown = () => {
   const { session, signOut } = useAuth();
+  const containerRef = useRef<HTMLDivElement>(null);
+
   if (!session) {
     return null;
   }
@@ -30,9 +60,10 @@ export const ProfileDropdown = () => {
   const avatarUrl = session.user.avatarUrl?.trim() || undefined;
 
   return (
-    <Popover className="relative flex">
+    <Popover ref={containerRef} className="relative flex">
       {({ close }) => (
         <>
+          <CloseOnOutsideClick containerRef={containerRef} close={close} />
           <Popover.Button
             aria-label="Account menu"
             className="flex size-10 items-center justify-center self-center rounded-full text-neutral-700 hover:bg-neutral-100 focus:outline-none dark:text-neutral-300 dark:hover:bg-neutral-800 sm:size-12"

--- a/frontend/tests/components/landing/header/auth-nav/dropdown.test.tsx
+++ b/frontend/tests/components/landing/header/auth-nav/dropdown.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProfileDropdown } from "@components/landing/header/auth-nav/dropdown";
+import type { AuthContextValue } from "@contexts/auth";
+
+const mockAuth: AuthContextValue = {
+  session: { user: { id: "u1", email: "jane@example.com" } } as AuthContextValue["session"],
+  ready: true,
+  signIn: vi.fn(),
+  signInWithGoogle: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+  refresh: vi.fn(),
+  error: null,
+  isSubmitting: false,
+};
+
+vi.mock("@contexts/auth", () => ({ useAuth: () => mockAuth }));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, onClick }: { href: string; children: React.ReactNode; onClick?: () => void }) => (
+    <a href={href} onClick={onClick}>{children}</a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
+}));
+
+describe("ProfileDropdown", () => {
+  it("closes when clicking outside the menu", async () => {
+    render(
+      <div>
+        <ProfileDropdown />
+        <div data-testid="outside">Outside content</div>
+      </div>,
+    );
+
+    fireEvent.click(screen.getByLabelText("Account menu"));
+    expect(screen.getByText("Account")).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    await waitFor(() => expect(screen.queryByText("Account")).not.toBeInTheDocument());
+  });
+
+  it("closes when the profile button is clicked again", async () => {
+    render(<ProfileDropdown />);
+
+    const button = screen.getByLabelText("Account menu");
+    fireEvent.click(button);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.queryByText("Account")).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed a 404 on `POST /account/password` caused by a doubled router prefix (`/account/account/password` → `/account/password`)
- Stopped re-fetching the auth user via the Admin API on `GET /account/profile`; the already-verified `current_user` from the token check is used instead, removing a redundant network round-trip that was an intermittent source of 503s
- Fixed the account profile dropdown not closing on outside click when the click landed on non-focusable page content

## Changes

- `backend/app/api/v1/endpoints/account/password.py` — remove duplicate `/account` prefix from the router
- `backend/app/api/v1/endpoints/account/profile.py` — use `current_user` instead of calling `get_auth_user` on GET
- `backend/tests/api/test_account.py`, `conftest.py` — update tests for corrected endpoint path and add coverage asserting the Admin API is not called on GET
- `frontend/components/landing/header/auth-nav/dropdown.tsx` — add explicit outside-click handling via a document `mousedown` listener instead of relying solely on Headless UI's internal detection
- `frontend/tests/components/landing/header/auth-nav/dropdown.test.tsx` — new tests for outside-click and toggle-close behavior

## Test plan

- [ ] Backend: `pytest backend/tests/api/test_account.py`
- [ ] Frontend: dropdown test suite (`dropdown.test.tsx`)
- [ ] Manually verify `POST /account/password` succeeds end-to-end
- [ ] Manually verify profile dropdown closes when clicking outside on plain page content