### PR TITLE
Record Supabase dashboard fix for Google sign-in redirecting to localhost

### DIFF
--- a/how-to-fix-google-signin-error.txt
+++ b/how-to-fix-google-signin-error.txt
@@ -1,0 +1,5 @@
+Fix (in the Supabase Dashboard, not code):
+
+Go to your project → Authentication → URL Configuration:
+1. Set Site URL to https://real-estate-consultant-fe.vercel.app
+2. Add https://real-estate-consultant-fe.vercel.app/auth/callback to Redirect URLs (you can also keep http://localhost:3000/** there for local dev)


### PR DESCRIPTION
### Problem
Clicking "Sign in with Google" on `/sign-in` redirected users to
`https://localhost:3000/?code=...` instead of the production callback route,
breaking the OAuth flow in production.

### Root cause
Not a code bug. `signInWithOAuth` correctly requests
`redirectTo: ${window.location.origin}/auth/callback`, but Supabase only
honors `redirectTo` if it matches an entry in the project's **Redirect URLs**
allow-list. Since it didn't, Supabase silently fell back to the project's
**Site URL**, which was still set to `http://localhost:3000` (the local-dev
default) — so post-auth users were sent to a domain nothing is running on in
production.

`middleware.ts` already forwards a stray `code` param from `/` to
`/auth/callback` for the case where the fallback lands on the app's own
domain, but that can't help when the fallback lands on a different host
entirely (`localhost:3000`), which is what was happening here.

### Fix
This is a Supabase Dashboard config change, applied under
**Authentication → URL Configuration**:
1. Set **Site URL** to `https://real-estate-consultant-fe.vercel.app`
2. Add `https://real-estate-consultant-fe.vercel.app/auth/callback` to
   **Redirect URLs** (kept `http://localhost:3000/**` for local dev)

This PR adds `how-to-fix-google-signin-error.txt` documenting the fix for
future reference.

### Test plan
- [ ] Click "Sign in with Google" on the deployed `/sign-in` page
- [ ] Confirm redirect lands on `/auth/callback` (not `localhost:3000`) and
      completes sign-in