### PR TITLE
Add Continue with Google to signup flow

### DIFF
--- a/frontend/components/auth/forms/sign-up.tsx
+++ b/frontend/components/auth/forms/sign-up.tsx
@@ -109,7 +109,7 @@ export const SignUpForm = () => {
 
       <AuthFormDivider />
 
-      <GoogleAuthButton label="Sign up with Google" />
+      <GoogleAuthButton label="Continue with Google" />
     </div>
   );
 };

--- a/frontend/components/auth/forms/sign-up.tsx
+++ b/frontend/components/auth/forms/sign-up.tsx
@@ -7,9 +7,11 @@ import { ButtonPrimary } from "@components/ui/button-primary";
 import { useAuth } from "@contexts/auth";
 
 import { AuthFormError } from "./error";
+import { AuthFormDivider } from "./divider";
 import { EmailField } from "../fields/email";
 import { PasswordField } from "../fields/password";
 import { TextField } from "../fields/text";
+import { GoogleAuthButton } from "./button";
 
 export const SignUpForm = () => {
   const router = useRouter();
@@ -104,6 +106,10 @@ export const SignUpForm = () => {
           {isSubmitting ? "Creating account…" : "Create account"}
         </ButtonPrimary>
       </form>
+
+      <AuthFormDivider />
+
+      <GoogleAuthButton label="Sign up with Google" />
     </div>
   );
 };

--- a/frontend/tests/components/auth/google-auth-button.test.tsx
+++ b/frontend/tests/components/auth/google-auth-button.test.tsx
@@ -34,8 +34,8 @@ describe("GoogleAuthButton", () => {
   });
 
   it("renders a custom label", () => {
-    render(<GoogleAuthButton label="Sign up with Google" />);
-    expect(screen.getByRole("button", { name: /sign up with google/i })).toBeInTheDocument();
+    render(<GoogleAuthButton label="Continue with Google" />);
+    expect(screen.getByRole("button", { name: /continue with google/i })).toBeInTheDocument();
   });
 
   it("calls signInWithGoogle when clicked", async () => {

--- a/frontend/tests/components/auth/sign-up-form.test.tsx
+++ b/frontend/tests/components/auth/sign-up-form.test.tsx
@@ -29,6 +29,10 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
 beforeEach(() => {
   mockAuth.signUp = vi.fn();
   mockAuth.error = null;


### PR DESCRIPTION
Fixed #79 

## Summary
- Add a "Sign up with Google" button to the signup form, reusing the existing `GoogleAuthButton` and `AuthFormDivider` components already used on the sign-in page.
- Signup via Google reuses the same Supabase OAuth path as sign-in (`signInWithOAuth`), which creates the account automatically if one doesn't exist yet — no new backend logic needed.
- Add the missing `next/image` mock to `sign-up-form.test.tsx` (matching the sign-in test) so the new `<Image>` in `GoogleAuthButton` renders correctly in tests.

## Test plan
- [x] Verified "Sign up with Google" renders with the Google icon on `/sign-up` via the running dev server
- [x] Confirmed clicking follows the same `signInWithGoogle` OAuth redirect flow used on sign-in
- [x] Note: the auth test suite (`sign-in-form`, `sign-up-form`, and 5 other files) currently fails on `main` independent of this change — confirmed via `git stash` before committing. Not addressed in this PR.