### PR TITLE
Remove Team section from About page

### DIFF
--- a/frontend/app/(landing)/about/page.tsx
+++ b/frontend/app/(landing)/about/page.tsx
@@ -87,32 +87,6 @@ const AboutPage = () => (
         </div>
       </div>
 
-      {/* Team */}
-      <div className="relative">
-        <SectionHeading desc="The people building RadEstate.">⛱ Team</SectionHeading>
-        <div className="grid gap-x-5 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
-          {TEAM.map((item) => (
-            <div key={item.id} className="max-w-sm">
-              <div className="relative aspect-square overflow-hidden rounded-xl">
-                <Image
-                  fill
-                  className="object-cover"
-                  src={item.avatar}
-                  alt={item.name}
-                  sizes="(max-width: 768px) 100vw, 30vw"
-                />
-              </div>
-              <h3 className="mt-4 text-lg font-semibold text-neutral-900 md:text-xl dark:text-neutral-200">
-                {item.name}
-              </h3>
-              <span className="block text-sm text-neutral-500 sm:text-base dark:text-neutral-400">
-                {item.job}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-
       <Testimonials />
     </div>
   </div>

--- a/frontend/components/landing/testimonials.tsx
+++ b/frontend/components/landing/testimonials.tsx
@@ -38,7 +38,7 @@ type TestimonialsProps = {
 
 export const Testimonials = ({ className }: TestimonialsProps) => (
   <div className={className}>
-    <SectionHeading isCenter desc="Why CRE professionals choose RadEstate.">
+    <SectionHeading desc="Why CRE professionals choose RadEstate.">
       What clients say
     </SectionHeading>
 


### PR DESCRIPTION
## Summary
- Remove the "Team" section (heading, avatars, and bios) from the About page — it's no longer part of the page.
- Left-align the Testimonials section heading ("What clients say") on the About/landing pages to match the rest of the section headings instead of centering it.

## Test plan
- [x] Verified `/about` renders correctly with the Team section removed
- [x] Verified the Testimonials heading is left-aligned via the dev server