### PR TITLE
Remove account section from footer

### DIFF
--- a/frontend/components/landing/footer/index.tsx
+++ b/frontend/components/landing/footer/index.tsx
@@ -31,16 +31,6 @@ const FOOTER_COLUMNS: FooterColumn[] = [
     ],
   },
   {
-    id: "account",
-    title: "Account",
-    items: [
-      { label: "Sign in", href: "/sign-in" },
-      { label: "Get started", href: "/sign-up" },
-      { label: "Your account", href: "/account" },
-      { label: "Saved", href: "/saved" },
-    ],
-  },
-  {
     id: "company",
     title: "Company",
     items: [


### PR DESCRIPTION
Fix #82 

Removes the "Account" column from the site footer (Sign in, Get started, Your account, Saved links).

### Changes
- Deleted the `account` entry from `FOOTER_COLUMNS` in `frontend/components/landing/footer/index.tsx`

### Test plan
- [ ] Verify the footer no longer shows the "Account" column
- [ ] Verify remaining footer columns (e.g. Company) still render correctly with proper spacing/layout