### PR TITLE
Add OpenRouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Internal MVP for an **AI-assisted commercial real estate search** workflow: intake, lawful listing ingestion, property understanding, fit-based ranking, saved searches and watchlists, and **draft** broker outreach (no auto-send).
 
-The app is built with **Next.js** and **FastAPI**, backed by **Supabase**, with LLMs accessed through **OpenRouter**. Details are in [Stack](#stack) below.
+The app is built with **Next.js** and **FastAPI**, backed by **Supabase**, with chat LLMs routed through **OpenRouter** and/or **Hugging Face** on the backend. Details are in [Stack](#stack) below.
 
 ---
 
@@ -13,7 +13,7 @@ The app is built with **Next.js** and **FastAPI**, backed by **Supabase**, with 
 | **Frontend** | [Next.js](https://nextjs.org/) | Product UI, intake, results, watchlists; server components and Route Handlers as appropriate |
 | **Backend** | [FastAPI](https://fastapi.tiangolo.com/) | APIs, modular listing ingestion, normalization, and orchestration of model calls |
 | **Data & platform** | [Supabase](https://supabase.com/) | Postgres, authentication, and other Supabase features (e.g. Storage) as the project needs them |
-| **LLM** | [OpenRouter](https://openrouter.ai/) | Model routing and API for extraction, fit summaries, ranking explanations, and outreach drafts |
+| **LLM** | [OpenRouter](https://openrouter.ai/) and/or [Hugging Face](https://huggingface.co/) | Structured chat for intake, fit summaries, and outreach drafts (`OPENROUTER_API_KEY` preferred when both keys are set) |
 
 Ingestion may integrate additional tools (for example **Apify** or similar) behind FastAPI; those are implementation details of each connector, not replacements for the core stack above.
 
@@ -62,7 +62,7 @@ The FastAPI API deploys as a **second Vercel project** via `.github/workflows/ba
 
 1. In Vercel, create/import a project with **Root Directory** = `backend` (or `cd backend && npx vercel link`).
 2. Add GitHub secrets **`VERCEL_BACKEND_PROJECT_ID`** (backend project ID) and reuse **`VERCEL_TOKEN`** / **`VERCEL_ORG_ID`**. The frontend workflow uses **`VERCEL_FRONTEND_PROJECT_ID`**.
-3. In the **backend** Vercel project → **Environment Variables** (Production), set variables from `backend/.env.example` (at minimum `DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `FRONTEND_ORIGIN` = your frontend Vercel URL).
+3. In the **backend** Vercel project → **Environment Variables** (Production), set variables from `backend/.env.example` (at minimum `DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `FRONTEND_ORIGIN` = your frontend Vercel URL, and at least one of `OPENROUTER_API_KEY` or `HF_TOKEN` for chat).
 4. Merge to **`main`** to run production deploy (`vercel deploy --prebuilt --prod`).
 
 **URL:** `https://<backend-project-name>.vercel.app` — use this as `NEXT_PUBLIC_BACKEND_API_URL` on the frontend. Routes are unchanged (`/health`, `/api/v1/...`, `/docs`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,41 +1,39 @@
-# Copy to .env and adjust as needed.
-APP_NAME=Real Estate Consultant API
+# Required — Postgres (Supabase). Use port 6543 + DB_SERVERLESS=true on Vercel serverless.
+DATABASE_URL=postgresql://postgres:password@db.xxxx.supabase.co:5432/postgres
+DB_SERVERLESS=false
 
-# Direct connection (local dev / migrations):
-DATABASE_URL=postgresql://postgres:PASSWORD@db.PROJECT_REF.supabase.co:5432/postgres
-# Supabase pgbouncer / Transaction pooler (recommended for Vercel serverless):
-# DATABASE_URL=postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres
-# DB_SERVERLESS=true   # must be true when pointing at pgbouncer (disables prepared statements + NullPool)
+# Required — Supabase project
+SUPABASE_URL=https://xxxx.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_ANON_KEY=your-anon-key
 
-SUPABASE_URL=https://PROJECT_REF.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=
-
-# Same as the Supabase anon (public) key — required for POST /account/password to verify the current password.
-SUPABASE_ANON_KEY=
-
-# Pepper for hashing MCP API keys (sha256 of pepper||raw_key). Use a long random string in any shared env.
-# Required once /api/v1/account/api-keys ships; leave empty only for local experiments.
-MCP_API_KEY_PEPPER=
-# Per-key MCP API auth limit (requests/minute, single process)
-MCP_API_KEY_RATE_LIMIT_PER_MINUTE=120
-
-
-# If true, Supabase creates the user with a confirmed email (can sign in immediately).
-SIGNUP_EMAIL_CONFIRM=true
-
-# Browser origins allowed to call this API (comma-separated). Include https:// too if
-# the Next dev server runs with --experimental-https.
+# Comma-separated browser origins allowed to call the API (Next dev/prod URLs).
 FRONTEND_ORIGIN=http://localhost:3000,https://localhost:3000
 
-#HuggingFace
-HF_MODEL=Qwen/Qwen2.5-7B-Instruct
-HF_TOKEN=
+# --- Chat LLM (Smart Chat, intake, fit, outreach) ---
+# Priority: OPENROUTER_API_KEY wins when set; else HF_TOKEN; else chat returns "AI unavailable".
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_CHAT_MODEL=meta-llama/llama-3.1-8b-instruct
+# Optional OpenRouter attribution headers
+OPENROUTER_HTTP_REFERER=
+OPENROUTER_APP_TITLE=Real Estate Consultant
 
-# Ingestion microservice (Phase 3). Empty URL disables the feature.
+HF_TOKEN=
+HF_MODEL=meta-llama/Meta-Llama-3.1-8B-Instruct
+HF_BASE_URL=https://router.huggingface.co/v1
+
+# Optional cost telemetry (USD per 1M tokens; 0 disables estimates)
+OPENROUTER_INPUT_COST_PER_1M=0
+OPENROUTER_OUTPUT_COST_PER_1M=0
+HF_INPUT_COST_PER_1M=0
+HF_OUTPUT_COST_PER_1M=0
+
+# MCP API keys (rad_…) — pepper for sha256(key) lookup; required in production
+MCP_API_KEY_PEPPER=
+
+# Ingestion microservice (optional — empty disables enqueue from backend)
 INGESTION_SERVICE_URL=
-# Must match the ingestion service's SERVICE_AUTH_TOKEN.
 INGESTION_SERVICE_TOKEN=
 
-# SolarWinds Observability bulk HTTP log ingestion. Leave blank to disable.
-SWO_LOGS_URL=https://logs.collector.na-01.cloud.solarwinds.com/v1/logs/bulk
-SWO_TOKEN=
+LOG_LEVEL=INFO

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,13 @@ OPENROUTER_APP_TITLE=Real Estate Consultant
 
 HF_TOKEN=
 HF_MODEL=meta-llama/Meta-Llama-3.1-8B-Instruct
+HF_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 HF_BASE_URL=https://router.huggingface.co/v1
+
+# --- Embeddings (separate resolver from chat) ---
+# Priority: HF_TOKEN wins when set; else OPENROUTER_API_KEY; else "Embeddings unavailable".
+# OPENROUTER_EMBEDDING_MODEL is used only when HF_TOKEN is empty and OPENROUTER_API_KEY is set.
+OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small
 
 # Optional cost telemetry (USD per 1M tokens; 0 disables estimates)
 OPENROUTER_INPUT_COST_PER_1M=0

--- a/backend/README.md
+++ b/backend/README.md
@@ -90,7 +90,7 @@ Smart Chat, intake parsing, fit explanations, and outreach drafts all call one c
 | `HF_TOKEN` only | **Hugging Face** |
 | neither | No LLM — API returns **503** with `"AI unavailable"` |
 
-Optional tuning: `OPENROUTER_CHAT_MODEL`, `OPENROUTER_BASE_URL`, `HF_MODEL`, `HF_BASE_URL`, and per-provider cost telemetry vars (see `.env.example`).
+Optional tuning: `OPENROUTER_CHAT_MODEL`, `OPENROUTER_BASE_URL`, `HF_MODEL`, `HF_BASE_URL`, and per-provider cost telemetry vars (see `.env.example`). Hugging Face chat uses JSON-object responses validated locally (avoids flaky grammar-constrained structured outputs on the Inference Providers router).
 
 ### Embeddings (OpenRouter + Hugging Face)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -102,7 +102,9 @@ Optional tuning: `OPENROUTER_CHAT_MODEL`, `OPENROUTER_BASE_URL`, `HF_MODEL`, `HF
 | `OPENROUTER_API_KEY` only | **OpenRouter** |
 | neither | **503** with `"Embeddings unavailable"` |
 
-Models: `HF_EMBEDDING_MODEL` (default `sentence-transformers/all-MiniLM-L6-v2`), `OPENROUTER_EMBEDDING_MODEL` (default `openai/text-embedding-3-small`). No product feature consumes embeddings yet; call `embed(texts=[...])` when adding semantic search / similarity.
+Models: `HF_EMBEDDING_MODEL` (default `sentence-transformers/all-MiniLM-L6-v2`), `OPENROUTER_EMBEDDING_MODEL` (default `openai/text-embedding-3-small`). Hugging Face embeddings use the Inference Providers **feature-extraction** pipeline (the OpenAI-compatible `…/v1` router is chat-only).
+
+**First consumer:** `GET /api/v1/listings/{property_id}/similar` — loads a small candidate pool (same state/city/type preferred), embeds seed + candidates via `embed()`, ranks by cosine similarity, returns scores on the same 0–100 scale as search `match_score`. Requires an embeddings key (`HF_TOKEN` preferred). No stored vectors / pgvector yet.
 
 ## Dataset
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -67,11 +67,32 @@ Running `fastapi dev` from the repo root **without** the `backend/app/main.py` p
 
 Copy `.env.example` to `.env` in this same directory and adjust values as needed.
 
-| Variable   | Purpose |
-|------------|---------|
-| `APP_NAME` | Title shown in the OpenAPI metadata |
-
 Environment values are loaded from `backend/.env` by path, so loading does not depend on the shell’s current working directory.
+
+### Core
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `DATABASE_URL` | yes | Postgres connection string (Supabase) |
+| `SUPABASE_URL` | yes | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | yes | Service role key for server-side Supabase calls |
+| `SUPABASE_ANON_KEY` | recommended | Anon key where the backend needs it |
+| `FRONTEND_ORIGIN` | recommended | Comma-separated CORS origins (Next dev/prod URLs) |
+| `DB_SERVERLESS` | Vercel | Set `true` when `DATABASE_URL` uses Supabase pgbouncer (port 6543) |
+
+### Chat LLM (OpenRouter + Hugging Face)
+
+Smart Chat, intake parsing, fit explanations, and outreach drafts all call one chat entry point (`app.llm.providers.chat`). Provider selection is by API keys only:
+
+| Keys set | Chat provider |
+|----------|---------------|
+| `OPENROUTER_API_KEY` | **OpenRouter** (wins even if `HF_TOKEN` is also set) |
+| `HF_TOKEN` only | **Hugging Face** |
+| neither | No LLM — API returns **503** with `"AI unavailable"` |
+
+Optional tuning: `OPENROUTER_CHAT_MODEL`, `OPENROUTER_BASE_URL`, `HF_MODEL`, `HF_BASE_URL`, and per-provider cost telemetry vars (see `.env.example`).
+
+Embeddings (future semantic search) will use a **separate** resolver from chat; not implemented yet.
 
 ## Dataset
 
@@ -123,7 +144,7 @@ ruff check app
 Use a **separate Vercel project** from the Next.js frontend (Root Directory = `backend/`).
 
 1. `cd backend && npx vercel link`
-2. Set **Production** env vars in Vercel from `.env.example` (`DATABASE_URL`, Supabase keys, `FRONTEND_ORIGIN`, `HF_TOKEN`, …).
+2. Set **Production** env vars in Vercel from `.env.example` (`DATABASE_URL`, Supabase keys, `FRONTEND_ORIGIN`, and at least one of `OPENROUTER_API_KEY` or `HF_TOKEN` for chat, …).
 3. Push to `main` — `.github/workflows/backend.yml` deploys with `VERCEL_BACKEND_PROJECT_ID`, or deploy locally with `vercel deploy --prod`.
 
 Entrypoint for the serverless bundle: `api/index.py` → `app.main:app` (see `vercel.json`).

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,7 +92,17 @@ Smart Chat, intake parsing, fit explanations, and outreach drafts all call one c
 
 Optional tuning: `OPENROUTER_CHAT_MODEL`, `OPENROUTER_BASE_URL`, `HF_MODEL`, `HF_BASE_URL`, and per-provider cost telemetry vars (see `.env.example`).
 
-Embeddings (future semantic search) will use a **separate** resolver from chat; not implemented yet.
+### Embeddings (OpenRouter + Hugging Face)
+
+`app.llm.providers.embeddings` uses a **separate** priority from chat so both keys can be set with chat on OpenRouter and embeddings on Hugging Face:
+
+| Keys set | Embeddings provider |
+|----------|---------------------|
+| `HF_TOKEN` | **Hugging Face** (wins even if `OPENROUTER_API_KEY` is also set) |
+| `OPENROUTER_API_KEY` only | **OpenRouter** |
+| neither | **503** with `"Embeddings unavailable"` |
+
+Models: `HF_EMBEDDING_MODEL` (default `sentence-transformers/all-MiniLM-L6-v2`), `OPENROUTER_EMBEDDING_MODEL` (default `openai/text-embedding-3-small`). No product feature consumes embeddings yet; call `embed(texts=[...])` when adding semantic search / similarity.
 
 ## Dataset
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,17 +48,20 @@ class Settings(BaseSettings):
 
     hf_token: str = Field(default="", validation_alias=AliasChoices("HF_TOKEN", "hf_token"))
     hf_model: str = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    hf_embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
     hf_base_url: str = "https://router.huggingface.co/v1"
     # USD per 1M tokens, for cost-attribution telemetry. 0 disables cost estimates.
     hf_input_cost_per_1m: float = 0.0
     hf_output_cost_per_1m: float = 0.0
 
     # Chat: OPENROUTER_API_KEY wins over HF_TOKEN when both are set (see llm.providers.chat).
+    # Embeddings: HF_TOKEN wins when both are set (see llm.providers.embeddings).
     openrouter_api_key: str = Field(
         default="", validation_alias=AliasChoices("OPENROUTER_API_KEY", "openrouter_api_key")
     )
     openrouter_base_url: str = "https://openrouter.ai/api/v1"
     openrouter_chat_model: str = "meta-llama/llama-3.1-8b-instruct"
+    openrouter_embedding_model: str = "openai/text-embedding-3-small"
     openrouter_http_referer: str = ""
     openrouter_app_title: str = "Real Estate Consultant"
     openrouter_input_cost_per_1m: float = 0.0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,12 +46,23 @@ class Settings(BaseSettings):
                 seen.setdefault(trimmed, None)
         return list(seen)
 
-    hf_token: str = ""
+    hf_token: str = Field(default="", validation_alias=AliasChoices("HF_TOKEN", "hf_token"))
     hf_model: str = "meta-llama/Meta-Llama-3.1-8B-Instruct"
     hf_base_url: str = "https://router.huggingface.co/v1"
     # USD per 1M tokens, for cost-attribution telemetry. 0 disables cost estimates.
     hf_input_cost_per_1m: float = 0.0
     hf_output_cost_per_1m: float = 0.0
+
+    # Chat: OPENROUTER_API_KEY wins over HF_TOKEN when both are set (see llm.providers.chat).
+    openrouter_api_key: str = Field(
+        default="", validation_alias=AliasChoices("OPENROUTER_API_KEY", "openrouter_api_key")
+    )
+    openrouter_base_url: str = "https://openrouter.ai/api/v1"
+    openrouter_chat_model: str = "meta-llama/llama-3.1-8b-instruct"
+    openrouter_http_referer: str = ""
+    openrouter_app_title: str = "Real Estate Consultant"
+    openrouter_input_cost_per_1m: float = 0.0
+    openrouter_output_cost_per_1m: float = 0.0
 
     log_level: str = "INFO"
 

--- a/backend/app/llm/__init__.py
+++ b/backend/app/llm/__init__.py
@@ -9,15 +9,16 @@ from app.llm.intake import (
     render_intake_response_schema,
     resolve_next_intake_question,
 )
-from app.llm.providers import huggingface_provider
+from app.llm.providers import generate_structured_output, resolve_chat_provider
 
 __all__ = [
     "INTAKE_OPENING_MESSAGE",
     "build_intake_response_schema",
-    "huggingface_provider",
+    "generate_structured_output",
     "parse_user_input",
     "extract_question_keys",
     "generate_opening_question",
     "render_intake_response_schema",
+    "resolve_chat_provider",
     "resolve_next_intake_question",
 ]

--- a/backend/app/llm/fit/service.py
+++ b/backend/app/llm/fit/service.py
@@ -8,7 +8,7 @@ from app.domain.criteria_search import parse_location_fields, parse_range
 from app.llm.fit.exceptions import raise_fit_explanation_empty
 from app.llm.fit.prompts import FIT_EXPLANATION_SYSTEM_PROMPT, build_fit_user_message
 from app.llm.fit.schema import FitExplanationLLM
-from app.llm.providers import huggingface_provider
+from app.llm.providers.chat import generate_structured_output
 
 _NO_CRITERIA_SUMMARY = (
     "No specific search criteria are set yet, so every listing scores neutrally. "
@@ -55,7 +55,7 @@ async def generate_fit_explanation(
         {"role": "system", "content": FIT_EXPLANATION_SYSTEM_PROMPT},
         {"role": "user", "content": user_content},
     ]
-    parsed = await huggingface_provider.generate_structured_output(
+    parsed = await generate_structured_output(
         messages=messages,
         response_format=FitExplanationLLM,
         temperature=0.2,

--- a/backend/app/llm/intake/service.py
+++ b/backend/app/llm/intake/service.py
@@ -14,7 +14,7 @@ from app.domain.intake_next_question import (
 from app.domain.intake_validation import merge_missing_fields
 from app.llm.intake.exceptions import raise_hf_opening_response_missing_text
 from app.llm.intake.schema import extract_question_keys, render_intake_response_schema
-from app.llm.providers import huggingface_provider
+from app.llm.providers.chat import generate_structured_output
 from app.llm.providers.prompts import (
     INTAKE_PARSE_SYSTEM_PROMPT_HEADER,
     INTAKE_PARSE_SYSTEM_PROMPT_RULES,
@@ -59,7 +59,7 @@ async def parse_user_input(
         },
         ensure_ascii=True,
     )
-    parsed_output = await huggingface_provider.generate_structured_output(
+    parsed_output = await generate_structured_output(
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
@@ -97,7 +97,7 @@ async def generate_opening_question(
     if options is not None:
         user_payload["question_options"] = options
 
-    response_output = await huggingface_provider.generate_structured_output(
+    response_output = await generate_structured_output(
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": json.dumps(user_payload, ensure_ascii=True)},

--- a/backend/app/llm/outreach/service.py
+++ b/backend/app/llm/outreach/service.py
@@ -7,7 +7,7 @@ from typing import Any
 from app.llm.outreach.exceptions import raise_outreach_email_empty
 from app.llm.outreach.prompts import OUTREACH_EMAIL_SYSTEM_PROMPT, build_outreach_user_message
 from app.llm.outreach.schema import OutreachDraftEmailLLM
-from app.llm.providers import huggingface_provider
+from app.llm.providers.chat import generate_structured_output
 
 
 async def generate_broker_outreach_draft(
@@ -26,7 +26,7 @@ async def generate_broker_outreach_draft(
         {"role": "system", "content": OUTREACH_EMAIL_SYSTEM_PROMPT},
         {"role": "user", "content": user_content},
     ]
-    parsed = await huggingface_provider.generate_structured_output(
+    parsed = await generate_structured_output(
         messages=messages,
         response_format=OutreachDraftEmailLLM,
         temperature=0.35,

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -1,12 +1,15 @@
 """LLM provider integrations."""
 
 from app.llm.providers.chat import generate_structured_output, resolve_chat_provider
+from app.llm.providers.embeddings import embed, resolve_embeddings_provider
 from app.llm.providers.huggingface import huggingface_provider
 from app.llm.providers.openrouter import openrouter_provider
 
 __all__ = [
+    "embed",
     "generate_structured_output",
     "huggingface_provider",
     "openrouter_provider",
     "resolve_chat_provider",
+    "resolve_embeddings_provider",
 ]

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -1,7 +1,9 @@
 """LLM provider integrations."""
 
 from app.llm.providers.huggingface import huggingface_provider
+from app.llm.providers.openrouter import openrouter_provider
 
 __all__ = [
     "huggingface_provider",
+    "openrouter_provider",
 ]

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -1,9 +1,12 @@
 """LLM provider integrations."""
 
+from app.llm.providers.chat import generate_structured_output, resolve_chat_provider
 from app.llm.providers.huggingface import huggingface_provider
 from app.llm.providers.openrouter import openrouter_provider
 
 __all__ = [
+    "generate_structured_output",
     "huggingface_provider",
     "openrouter_provider",
+    "resolve_chat_provider",
 ]

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -1,4 +1,4 @@
-"""Shared protocol for chat LLM providers."""
+"""Shared protocols for LLM providers."""
 
 from __future__ import annotations
 
@@ -21,4 +21,12 @@ class ChatProvider(Protocol):
         max_tokens: int,
     ) -> StructuredOutputT:
         """Return a typed structured completion for the given messages."""
+        ...
+
+
+class EmbeddingsProvider(Protocol):
+    """OpenAI-compatible text embeddings provider."""
+
+    async def embed(self, *, texts: list[str]) -> list[list[float]]:
+        """Return one embedding vector per input text, in order."""
         ...

--- a/backend/app/llm/providers/base.py
+++ b/backend/app/llm/providers/base.py
@@ -1,0 +1,24 @@
+"""Shared protocol for chat LLM providers."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+StructuredOutputT = TypeVar("StructuredOutputT", bound=BaseModel)
+
+
+class ChatProvider(Protocol):
+    """OpenAI-compatible structured chat completion provider."""
+
+    async def generate_structured_output(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        response_format: type[StructuredOutputT],
+        temperature: float,
+        max_tokens: int,
+    ) -> StructuredOutputT:
+        """Return a typed structured completion for the given messages."""
+        ...

--- a/backend/app/llm/providers/chat.py
+++ b/backend/app/llm/providers/chat.py
@@ -1,0 +1,52 @@
+"""Chat inference entry point: resolve OpenRouter vs Hugging Face by env keys."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from app.core.config import Settings
+from app.core.config import settings as app_settings
+from app.llm.providers.base import ChatProvider, StructuredOutputT
+from app.llm.providers.exceptions import raise_ai_unavailable
+from app.llm.providers.huggingface import huggingface_provider
+from app.llm.providers.openrouter import openrouter_provider
+
+ChatProviderName = Literal["openrouter", "huggingface"]
+
+
+def resolve_chat_provider_name(*, config: Settings) -> ChatProviderName | None:
+    """Return the configured chat provider name, or None when no LLM keys are set."""
+    if config.openrouter_api_key.strip():
+        return "openrouter"
+    if config.hf_token.strip():
+        return "huggingface"
+    return None
+
+
+def resolve_chat_provider(*, config: Settings | None = None) -> ChatProvider:
+    """Return the active chat provider; raises 503 when no LLM keys are configured."""
+    active_config = config or app_settings
+    provider_name = resolve_chat_provider_name(config=active_config)
+    if provider_name == "openrouter":
+        return openrouter_provider
+    if provider_name == "huggingface":
+        return huggingface_provider
+    raise_ai_unavailable()
+
+
+async def generate_structured_output(
+    *,
+    messages: list[dict[str, Any]],
+    response_format: type[StructuredOutputT],
+    temperature: float,
+    max_tokens: int,
+    config: Settings | None = None,
+) -> StructuredOutputT:
+    """Structured chat completion via the configured provider (OpenRouter preferred)."""
+    provider = resolve_chat_provider(config=config)
+    return await provider.generate_structured_output(
+        messages=messages,
+        response_format=response_format,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )

--- a/backend/app/llm/providers/embeddings.py
+++ b/backend/app/llm/providers/embeddings.py
@@ -1,0 +1,48 @@
+"""Embeddings entry point: resolve Hugging Face vs OpenRouter by env keys.
+
+Priority differs from chat: HF_TOKEN wins when both keys are set so chat can
+stay on OpenRouter while embeddings use HF-native models.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from app.core.config import Settings
+from app.core.config import settings as app_settings
+from app.llm.providers.base import EmbeddingsProvider
+from app.llm.providers.exceptions import raise_embeddings_unavailable
+from app.llm.providers.huggingface import huggingface_provider
+from app.llm.providers.openrouter import openrouter_provider
+
+EmbeddingsProviderName = Literal["huggingface", "openrouter"]
+
+
+def resolve_embeddings_provider_name(*, config: Settings) -> EmbeddingsProviderName | None:
+    """Return the configured embeddings provider name, or None when no keys are set."""
+    if config.hf_token.strip():
+        return "huggingface"
+    if config.openrouter_api_key.strip():
+        return "openrouter"
+    return None
+
+
+def resolve_embeddings_provider(*, config: Settings | None = None) -> EmbeddingsProvider:
+    """Return the active embeddings provider; raises 503 when no keys are configured."""
+    active_config = config or app_settings
+    provider_name = resolve_embeddings_provider_name(config=active_config)
+    if provider_name == "huggingface":
+        return huggingface_provider
+    if provider_name == "openrouter":
+        return openrouter_provider
+    raise_embeddings_unavailable()
+
+
+async def embed(
+    *,
+    texts: list[str],
+    config: Settings | None = None,
+) -> list[list[float]]:
+    """Embed texts via the configured provider (Hugging Face preferred when both keys set)."""
+    provider = resolve_embeddings_provider(config=config)
+    return await provider.embed(texts=texts)

--- a/backend/app/llm/providers/exceptions.py
+++ b/backend/app/llm/providers/exceptions.py
@@ -14,11 +14,26 @@ from app.utils.exceptions import (
 )
 
 
+def raise_ai_unavailable() -> NoReturn:
+    raise_service_unavailable("AI unavailable")
+
+
 def raise_hf_api_key_not_configured() -> NoReturn:
     raise_service_unavailable("Hugging Face API key is not configured.")
 
 
+def raise_openrouter_api_key_not_configured() -> NoReturn:
+    raise_service_unavailable("OpenRouter API key is not configured.")
+
+
 def raise_hf_completion_parse_failed(*, cause: ValidationError) -> NoReturn:
+    raise_bad_gateway(
+        "We couldn't process the assistant's reply. Please try again in a moment.",
+        cause=cause,
+    )
+
+
+def raise_openrouter_completion_parse_failed(*, cause: ValidationError) -> NoReturn:
     raise_bad_gateway(
         "We couldn't process the assistant's reply. Please try again in a moment.",
         cause=cause,
@@ -29,7 +44,18 @@ def raise_hf_request_timeout(*, cause: APITimeoutError) -> NoReturn:
     raise_gateway_timeout("Timed out while calling Hugging Face API.", cause=cause)
 
 
+def raise_openrouter_request_timeout(*, cause: APITimeoutError) -> NoReturn:
+    raise_gateway_timeout("Timed out while calling OpenRouter API.", cause=cause)
+
+
 def raise_hf_openai_error(*, cause: OpenAIError) -> NoReturn:
+    raise_bad_gateway(
+        "The AI service is temporarily unavailable. Please try again later.",
+        cause=cause,
+    )
+
+
+def raise_openrouter_openai_error(*, cause: OpenAIError) -> NoReturn:
     raise_bad_gateway(
         "The AI service is temporarily unavailable. Please try again later.",
         cause=cause,
@@ -42,7 +68,20 @@ def raise_hf_structured_refusal(*, refusal: str) -> NoReturn:
     )
 
 
+def raise_openrouter_structured_refusal(*, refusal: str) -> NoReturn:
+    raise_bad_gateway(
+        "The AI service was unable to process this request. Please try again later.",
+    )
+
+
 def raise_hf_structured_reply_incomplete() -> NoReturn:
+    raise_bad_gateway(
+        "The assistant's reply didn't come through completely. "
+        "Please try again in a moment.",
+    )
+
+
+def raise_openrouter_structured_reply_incomplete() -> NoReturn:
     raise_bad_gateway(
         "The assistant's reply didn't come through completely. "
         "Please try again in a moment.",

--- a/backend/app/llm/providers/exceptions.py
+++ b/backend/app/llm/providers/exceptions.py
@@ -18,6 +18,10 @@ def raise_ai_unavailable() -> NoReturn:
     raise_service_unavailable("AI unavailable")
 
 
+def raise_embeddings_unavailable() -> NoReturn:
+    raise_service_unavailable("Embeddings unavailable")
+
+
 def raise_hf_api_key_not_configured() -> NoReturn:
     raise_service_unavailable("Hugging Face API key is not configured.")
 

--- a/backend/app/llm/providers/huggingface.py
+++ b/backend/app/llm/providers/huggingface.py
@@ -64,13 +64,18 @@ class HuggingFaceProvider:
         outcome: str,
         duration_ms: float,
         usage: CompletionUsage | None = None,
+        model: str | None = None,
     ) -> None:
         cost_usd = None
-        if usage is not None:
+        prompt_tokens = getattr(usage, "prompt_tokens", None) if usage is not None else None
+        completion_tokens = getattr(usage, "completion_tokens", None) if usage is not None else None
+        total_tokens = getattr(usage, "total_tokens", None) if usage is not None else None
+        if usage is not None and prompt_tokens is not None:
+            completion_for_cost = completion_tokens or 0
             cost_usd = round(
                 (
-                    usage.prompt_tokens * self.settings.hf_input_cost_per_1m
-                    + usage.completion_tokens * self.settings.hf_output_cost_per_1m
+                    prompt_tokens * self.settings.hf_input_cost_per_1m
+                    + completion_for_cost * self.settings.hf_output_cost_per_1m
                 )
                 / 1_000_000,
                 6,
@@ -79,12 +84,12 @@ class HuggingFaceProvider:
             "llm_call",
             extra={
                 "provider": "huggingface",
-                "model": self.settings.hf_model,
+                "model": model or self.settings.hf_model,
                 "outcome": outcome,
                 "duration_ms": round(duration_ms, 2),
-                "prompt_tokens": usage.prompt_tokens if usage else None,
-                "completion_tokens": usage.completion_tokens if usage else None,
-                "total_tokens": usage.total_tokens if usage else None,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
                 "estimated_cost_usd": cost_usd,
             },
         )
@@ -130,6 +135,37 @@ class HuggingFaceProvider:
             raise_hf_structured_refusal(refusal=str(message.refusal))
         self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
         raise_hf_structured_reply_incomplete()
+
+    async def embed(self, *, texts: list[str]) -> list[list[float]]:
+        """Return one embedding vector per input text via the Hugging Face router."""
+        if not texts:
+            return []
+        if not self.settings.hf_token.strip():
+            raise_hf_api_key_not_configured()
+
+        start = time.perf_counter()
+        try:
+            response = await self.client.embeddings.create(
+                model=self.settings.hf_embedding_model,
+                input=texts,
+            )
+        except APITimeoutError as exc:
+            self._log_call(outcome="timeout", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_hf_request_timeout(cause=exc)
+        except OpenAIError as exc:
+            self._log_call(outcome="error", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_hf_openai_error(cause=exc)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        # OpenAI returns data ordered by index; sort defensively.
+        ordered = sorted(response.data, key=lambda item: item.index)
+        self._log_call(
+            outcome="success",
+            duration_ms=duration_ms,
+            usage=response.usage,
+            model=self.settings.hf_embedding_model,
+        )
+        return [list(item.embedding) for item in ordered]
 
 
 huggingface_provider = HuggingFaceProvider(settings=settings)

--- a/backend/app/llm/providers/huggingface.py
+++ b/backend/app/llm/providers/huggingface.py
@@ -20,6 +20,7 @@ from app.llm.providers.exceptions import (
     raise_hf_structured_refusal,
     raise_hf_structured_reply_incomplete,
 )
+from app.utils.exceptions import raise_bad_gateway, raise_gateway_timeout
 
 HF_CONNECT_TIMEOUT = 20.0
 HF_READ_TIMEOUT = 75.0
@@ -136,36 +137,106 @@ class HuggingFaceProvider:
         self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
         raise_hf_structured_reply_incomplete()
 
+    def _feature_extraction_url(self) -> str:
+        """HF OpenAI router (`…/v1`) is chat-only; embeddings use feature-extraction."""
+        root = self.settings.hf_base_url.rstrip("/").removesuffix("/v1")
+        model = self.settings.hf_embedding_model.strip().strip("/")
+        return f"{root}/hf-inference/models/{model}/pipeline/feature-extraction"
+
+    @staticmethod
+    def _normalize_feature_extraction(
+        payload: object,
+        *,
+        expected: int,
+    ) -> list[list[float]]:
+        """Normalize HF feature-extraction JSON into one float vector per input text."""
+        if not isinstance(payload, list) or not payload:
+            raise_bad_gateway("Hugging Face returned an empty embedding response.")
+
+        first = payload[0]
+        # Single sentence vector: [float, …]
+        if isinstance(first, (int, float)):
+            vectors = [[float(x) for x in payload]]
+        # Batch of sentence vectors: [[float, …], …]
+        elif isinstance(first, list) and first and isinstance(first[0], (int, float)):
+            vectors = [[float(x) for x in row] for row in payload if isinstance(row, list)]
+        # Token-level embeddings: [[[float, …], …], …] — mean-pool each sequence
+        elif isinstance(first, list) and first and isinstance(first[0], list):
+            vectors = []
+            for sequence in payload:
+                if not isinstance(sequence, list) or not sequence:
+                    continue
+                width = len(sequence[0]) if isinstance(sequence[0], list) else 0
+                if width == 0:
+                    continue
+                sums = [0.0] * width
+                count = 0
+                for token in sequence:
+                    if not isinstance(token, list) or len(token) != width:
+                        continue
+                    for i, value in enumerate(token):
+                        sums[i] += float(value)
+                    count += 1
+                if count:
+                    vectors.append([value / count for value in sums])
+        else:
+            raise_bad_gateway("Hugging Face returned an unexpected embedding shape.")
+
+        if len(vectors) != expected:
+            raise_bad_gateway(
+                "Hugging Face embedding count did not match the number of input texts.",
+            )
+        return vectors
+
     async def embed(self, *, texts: list[str]) -> list[list[float]]:
-        """Return one embedding vector per input text via the Hugging Face router."""
+        """Return one embedding vector per input text via HF feature-extraction.
+
+        ``router.huggingface.co/v1`` is chat-completions only; sentence embeddings
+        go through ``/hf-inference/models/.../pipeline/feature-extraction``.
+        """
         if not texts:
             return []
         if not self.settings.hf_token.strip():
             raise_hf_api_key_not_configured()
 
+        url = self._feature_extraction_url()
+        headers = {
+            "Authorization": f"Bearer {self.settings.hf_token.strip()}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
         start = time.perf_counter()
         try:
-            response = await self.client.embeddings.create(
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(url, headers=headers, json={"inputs": texts})
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.TimeoutException as exc:
+            self._log_call(
+                outcome="timeout",
+                duration_ms=(time.perf_counter() - start) * 1000,
                 model=self.settings.hf_embedding_model,
-                input=texts,
             )
-        except APITimeoutError as exc:
-            self._log_call(outcome="timeout", duration_ms=(time.perf_counter() - start) * 1000)
-            raise_hf_request_timeout(cause=exc)
-        except OpenAIError as exc:
-            self._log_call(outcome="error", duration_ms=(time.perf_counter() - start) * 1000)
-            raise_hf_openai_error(cause=exc)
+            raise_gateway_timeout("Timed out while calling Hugging Face API.", cause=exc)
+        except httpx.HTTPError as exc:
+            self._log_call(
+                outcome="error",
+                duration_ms=(time.perf_counter() - start) * 1000,
+                model=self.settings.hf_embedding_model,
+            )
+            raise_bad_gateway(
+                "The AI service is temporarily unavailable. Please try again later.",
+                cause=exc,
+            )
 
+        vectors = self._normalize_feature_extraction(payload, expected=len(texts))
         duration_ms = (time.perf_counter() - start) * 1000
-        # OpenAI returns data ordered by index; sort defensively.
-        ordered = sorted(response.data, key=lambda item: item.index)
         self._log_call(
             outcome="success",
             duration_ms=duration_ms,
-            usage=response.usage,
             model=self.settings.hf_embedding_model,
         )
-        return [list(item.embedding) for item in ordered]
+        return vectors
 
 
 huggingface_provider = HuggingFaceProvider(settings=settings)

--- a/backend/app/llm/providers/huggingface.py
+++ b/backend/app/llm/providers/huggingface.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import time
 from typing import Any, TypeVar
 
@@ -27,6 +29,11 @@ HF_READ_TIMEOUT = 75.0
 HF_WRITE_TIMEOUT = 30.0
 HF_POOL_TIMEOUT = 10.0
 HF_TRANSIENT_RETRIES = 3
+
+_JSON_FENCE_RE = re.compile(
+    r"```(?:json)?\s*([\s\S]*?)\s*```",
+    re.IGNORECASE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +102,35 @@ class HuggingFaceProvider:
             },
         )
 
+    @staticmethod
+    def _extract_json_object(text: str) -> str:
+        """Pull a JSON object out of model text (raw or fenced)."""
+        stripped = text.strip()
+        if not stripped:
+            return stripped
+        fenced = _JSON_FENCE_RE.search(stripped)
+        if fenced:
+            return fenced.group(1).strip()
+        start = stripped.find("{")
+        end = stripped.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            return stripped[start : end + 1]
+        return stripped
+
+    def _structured_messages(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        response_format: type[BaseModel],
+    ) -> list[dict[str, Any]]:
+        schema = response_format.model_json_schema()
+        instruction = (
+            "Respond with a single JSON object that validates against this JSON Schema. "
+            "Do not wrap the JSON in markdown fences or add commentary.\n"
+            f"{json.dumps(schema, ensure_ascii=True)}"
+        )
+        return [{"role": "system", "content": instruction}, *messages]
+
     async def generate_structured_output(
         self,
         *,
@@ -103,22 +139,43 @@ class HuggingFaceProvider:
         temperature: float,
         max_tokens: int,
     ) -> StructuredOutputT:
-        """Request a typed structured output from the Hugging Face router."""
+        """Request typed JSON from Hugging Face and validate with Pydantic.
+
+        Avoids ``beta.chat.completions.parse`` / grammar-constrained structured
+        outputs: HF Inference Providers often return 422
+        ``grammar is not valid: failed to compile grammar`` depending on which
+        upstream provider the router selects for the same model id.
+        """
         if not self.settings.hf_token.strip():
             raise_hf_api_key_not_configured()
 
+        request_messages = self._structured_messages(
+            messages=messages,
+            response_format=response_format,
+        )
         start = time.perf_counter()
         try:
-            completion = await self.client.beta.chat.completions.parse(
-                model=self.settings.hf_model,
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                response_format=response_format,
-            )
-        except ValidationError as exc:
-            self._log_call(outcome="parse_failed", duration_ms=(time.perf_counter() - start) * 1000)
-            raise_hf_completion_parse_failed(cause=exc)
+            try:
+                completion = await self.client.chat.completions.create(
+                    model=self.settings.hf_model,
+                    messages=request_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    response_format={"type": "json_object"},
+                )
+            except APITimeoutError:
+                raise
+            except OpenAIError as json_mode_exc:
+                # Some router backends reject json_object; retry unconstrained.
+                status = getattr(json_mode_exc, "status_code", None)
+                if status not in {400, 404, 422}:
+                    raise
+                completion = await self.client.chat.completions.create(
+                    model=self.settings.hf_model,
+                    messages=request_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
         except APITimeoutError as exc:
             self._log_call(outcome="timeout", duration_ms=(time.perf_counter() - start) * 1000)
             raise_hf_request_timeout(cause=exc)
@@ -128,14 +185,28 @@ class HuggingFaceProvider:
 
         duration_ms = (time.perf_counter() - start) * 1000
         message = completion.choices[0].message
-        if message.parsed is not None:
-            self._log_call(outcome="success", duration_ms=duration_ms, usage=completion.usage)
-            return message.parsed
         if message.refusal:
             self._log_call(outcome="refusal", duration_ms=duration_ms, usage=completion.usage)
             raise_hf_structured_refusal(refusal=str(message.refusal))
-        self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
-        raise_hf_structured_reply_incomplete()
+        content = (message.content or "").strip()
+        if not content:
+            self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
+            raise_hf_structured_reply_incomplete()
+
+        try:
+            parsed = response_format.model_validate_json(self._extract_json_object(content))
+        except ValidationError as exc:
+            self._log_call(outcome="parse_failed", duration_ms=duration_ms, usage=completion.usage)
+            raise_hf_completion_parse_failed(cause=exc)
+        except (json.JSONDecodeError, ValueError) as exc:
+            self._log_call(outcome="parse_failed", duration_ms=duration_ms, usage=completion.usage)
+            raise_bad_gateway(
+                "We couldn't process the assistant's reply. Please try again in a moment.",
+                cause=exc,
+            )
+
+        self._log_call(outcome="success", duration_ms=duration_ms, usage=completion.usage)
+        return parsed
 
     def _feature_extraction_url(self) -> str:
         """HF OpenAI router (`…/v1`) is chat-only; embeddings use feature-extraction."""

--- a/backend/app/llm/providers/openrouter.py
+++ b/backend/app/llm/providers/openrouter.py
@@ -70,13 +70,18 @@ class OpenRouterProvider:
         outcome: str,
         duration_ms: float,
         usage: CompletionUsage | None = None,
+        model: str | None = None,
     ) -> None:
         cost_usd = None
-        if usage is not None:
+        prompt_tokens = getattr(usage, "prompt_tokens", None) if usage is not None else None
+        completion_tokens = getattr(usage, "completion_tokens", None) if usage is not None else None
+        total_tokens = getattr(usage, "total_tokens", None) if usage is not None else None
+        if usage is not None and prompt_tokens is not None:
+            completion_for_cost = completion_tokens or 0
             cost_usd = round(
                 (
-                    usage.prompt_tokens * self.settings.openrouter_input_cost_per_1m
-                    + usage.completion_tokens * self.settings.openrouter_output_cost_per_1m
+                    prompt_tokens * self.settings.openrouter_input_cost_per_1m
+                    + completion_for_cost * self.settings.openrouter_output_cost_per_1m
                 )
                 / 1_000_000,
                 6,
@@ -85,12 +90,12 @@ class OpenRouterProvider:
             "llm_call",
             extra={
                 "provider": "openrouter",
-                "model": self.settings.openrouter_chat_model,
+                "model": model or self.settings.openrouter_chat_model,
                 "outcome": outcome,
                 "duration_ms": round(duration_ms, 2),
-                "prompt_tokens": usage.prompt_tokens if usage else None,
-                "completion_tokens": usage.completion_tokens if usage else None,
-                "total_tokens": usage.total_tokens if usage else None,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
                 "estimated_cost_usd": cost_usd,
             },
         )
@@ -136,6 +141,36 @@ class OpenRouterProvider:
             raise_openrouter_structured_refusal(refusal=str(message.refusal))
         self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
         raise_openrouter_structured_reply_incomplete()
+
+    async def embed(self, *, texts: list[str]) -> list[list[float]]:
+        """Return one embedding vector per input text via OpenRouter."""
+        if not texts:
+            return []
+        if not self.settings.openrouter_api_key.strip():
+            raise_openrouter_api_key_not_configured()
+
+        start = time.perf_counter()
+        try:
+            response = await self.client.embeddings.create(
+                model=self.settings.openrouter_embedding_model,
+                input=texts,
+            )
+        except APITimeoutError as exc:
+            self._log_call(outcome="timeout", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_openrouter_request_timeout(cause=exc)
+        except OpenAIError as exc:
+            self._log_call(outcome="error", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_openrouter_openai_error(cause=exc)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        ordered = sorted(response.data, key=lambda item: item.index)
+        self._log_call(
+            outcome="success",
+            duration_ms=duration_ms,
+            usage=response.usage,
+            model=self.settings.openrouter_embedding_model,
+        )
+        return [list(item.embedding) for item in ordered]
 
 
 openrouter_provider = OpenRouterProvider(settings=settings)

--- a/backend/app/llm/providers/openrouter.py
+++ b/backend/app/llm/providers/openrouter.py
@@ -1,0 +1,141 @@
+"""OpenRouter provider wrapper built on the OpenAI Python SDK."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, TypeVar
+
+import httpx
+from openai import APITimeoutError, AsyncOpenAI, OpenAIError
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel, ValidationError
+
+from app.core.config import Settings, settings
+from app.llm.providers.exceptions import (
+    raise_openrouter_api_key_not_configured,
+    raise_openrouter_completion_parse_failed,
+    raise_openrouter_openai_error,
+    raise_openrouter_request_timeout,
+    raise_openrouter_structured_refusal,
+    raise_openrouter_structured_reply_incomplete,
+)
+
+OR_CONNECT_TIMEOUT = 20.0
+OR_READ_TIMEOUT = 75.0
+OR_WRITE_TIMEOUT = 30.0
+OR_POOL_TIMEOUT = 10.0
+OR_TRANSIENT_RETRIES = 3
+
+logger = logging.getLogger(__name__)
+
+StructuredOutputT = TypeVar("StructuredOutputT", bound=BaseModel)
+
+
+class OpenRouterProvider:
+    """Provider client for OpenRouter OpenAI-compatible chat completions."""
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        timeout: httpx.Timeout | None = None,
+        transient_retries: int = OR_TRANSIENT_RETRIES,
+        client: AsyncOpenAI | None = None,
+    ) -> None:
+        self.settings = settings
+        self.timeout = timeout or httpx.Timeout(
+            connect=OR_CONNECT_TIMEOUT,
+            read=OR_READ_TIMEOUT,
+            write=OR_WRITE_TIMEOUT,
+            pool=OR_POOL_TIMEOUT,
+        )
+        self.transient_retries = transient_retries
+        default_headers: dict[str, str] = {}
+        if settings.openrouter_http_referer.strip():
+            default_headers["HTTP-Referer"] = settings.openrouter_http_referer.strip()
+        if settings.openrouter_app_title.strip():
+            default_headers["X-Title"] = settings.openrouter_app_title.strip()
+        self.client = client or AsyncOpenAI(
+            api_key=settings.openrouter_api_key or "missing-openrouter-api-key",
+            base_url=settings.openrouter_base_url,
+            timeout=self.timeout,
+            max_retries=transient_retries,
+            default_headers=default_headers or None,
+        )
+
+    def _log_call(
+        self,
+        *,
+        outcome: str,
+        duration_ms: float,
+        usage: CompletionUsage | None = None,
+    ) -> None:
+        cost_usd = None
+        if usage is not None:
+            cost_usd = round(
+                (
+                    usage.prompt_tokens * self.settings.openrouter_input_cost_per_1m
+                    + usage.completion_tokens * self.settings.openrouter_output_cost_per_1m
+                )
+                / 1_000_000,
+                6,
+            )
+        logger.info(
+            "llm_call",
+            extra={
+                "provider": "openrouter",
+                "model": self.settings.openrouter_chat_model,
+                "outcome": outcome,
+                "duration_ms": round(duration_ms, 2),
+                "prompt_tokens": usage.prompt_tokens if usage else None,
+                "completion_tokens": usage.completion_tokens if usage else None,
+                "total_tokens": usage.total_tokens if usage else None,
+                "estimated_cost_usd": cost_usd,
+            },
+        )
+
+    async def generate_structured_output(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        response_format: type[StructuredOutputT],
+        temperature: float,
+        max_tokens: int,
+    ) -> StructuredOutputT:
+        """Request a typed structured output from OpenRouter."""
+        if not self.settings.openrouter_api_key.strip():
+            raise_openrouter_api_key_not_configured()
+
+        start = time.perf_counter()
+        try:
+            completion = await self.client.beta.chat.completions.parse(
+                model=self.settings.openrouter_chat_model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                response_format=response_format,
+            )
+        except ValidationError as exc:
+            self._log_call(outcome="parse_failed", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_openrouter_completion_parse_failed(cause=exc)
+        except APITimeoutError as exc:
+            self._log_call(outcome="timeout", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_openrouter_request_timeout(cause=exc)
+        except OpenAIError as exc:
+            self._log_call(outcome="error", duration_ms=(time.perf_counter() - start) * 1000)
+            raise_openrouter_openai_error(cause=exc)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        message = completion.choices[0].message
+        if message.parsed is not None:
+            self._log_call(outcome="success", duration_ms=duration_ms, usage=completion.usage)
+            return message.parsed
+        if message.refusal:
+            self._log_call(outcome="refusal", duration_ms=duration_ms, usage=completion.usage)
+            raise_openrouter_structured_refusal(refusal=str(message.refusal))
+        self._log_call(outcome="incomplete", duration_ms=duration_ms, usage=completion.usage)
+        raise_openrouter_structured_reply_incomplete()
+
+
+openrouter_provider = OpenRouterProvider(settings=settings)

--- a/backend/tests/llm/fit/test_service.py
+++ b/backend/tests/llm/fit/test_service.py
@@ -19,7 +19,7 @@ class TestGenerateFitExplanation:
             considerations=[],
         )
         with patch(
-            "app.llm.fit.service.huggingface_provider.generate_structured_output",
+            "app.llm.fit.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ):
@@ -38,7 +38,7 @@ class TestGenerateFitExplanation:
         object.__setattr__(parsed, "strengths", [])
         object.__setattr__(parsed, "considerations", [])
         with patch(
-            "app.llm.fit.service.huggingface_provider.generate_structured_output",
+            "app.llm.fit.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ):
@@ -54,7 +54,7 @@ class TestGenerateFitExplanation:
 
     async def test_no_criteria_short_circuits_without_llm_call(self):
         with patch(
-            "app.llm.fit.service.huggingface_provider.generate_structured_output",
+            "app.llm.fit.service.generate_structured_output",
             new_callable=AsyncMock,
         ) as mock_gen:
             result = await generate_fit_explanation(
@@ -74,7 +74,7 @@ class TestGenerateFitExplanation:
             considerations=["No price range set to compare against"],
         )
         with patch(
-            "app.llm.fit.service.huggingface_provider.generate_structured_output",
+            "app.llm.fit.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ) as mock_gen:

--- a/backend/tests/llm/intake/test_service.py
+++ b/backend/tests/llm/intake/test_service.py
@@ -175,7 +175,7 @@ class TestGenerateOpeningQuestion:
     async def test_returns_stripped_text(self):
         mock_output = LlmOpeningQuestionOutput(text="  Hello! What city?  ")
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ):
@@ -189,7 +189,7 @@ class TestGenerateOpeningQuestion:
     async def test_empty_text_raises_502(self):
         mock_output = LlmOpeningQuestionOutput(text="")
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ):
@@ -204,7 +204,7 @@ class TestGenerateOpeningQuestion:
     async def test_options_appends_hint_to_system_prompt(self):
         mock_output = LlmOpeningQuestionOutput(text="Choose one:")
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ) as mock_gen:
@@ -223,7 +223,7 @@ class TestGenerateOpeningQuestion:
     async def test_no_options_user_payload_excludes_options_field(self):
         mock_output = LlmOpeningQuestionOutput(text="Where?")
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ) as mock_gen:
@@ -255,7 +255,7 @@ class TestParseUserInput:
             missing=["budget"],
         )
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ):
@@ -271,7 +271,7 @@ class TestParseUserInput:
     async def test_previously_skipped_excluded_from_criteria_for_prompt(self):
         mock_output = _parsed_output()
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ) as mock_gen:
@@ -293,7 +293,7 @@ class TestParseUserInput:
             is_complete=True,
         )
         with patch(
-            "app.llm.intake.service.huggingface_provider.generate_structured_output",
+            "app.llm.intake.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=mock_output,
         ):

--- a/backend/tests/llm/outreach/test_service.py
+++ b/backend/tests/llm/outreach/test_service.py
@@ -20,7 +20,7 @@ class TestGenerateBrokerOutreachDraft:
     async def test_returns_draft_text(self):
         parsed = OutreachDraftEmailLLM(draft_email="Dear Bob,\n\nI am writing to inquire about your property at 100 Main St.")
         with patch(
-            "app.llm.outreach.service.huggingface_provider.generate_structured_output",
+            "app.llm.outreach.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ):
@@ -31,7 +31,7 @@ class TestGenerateBrokerOutreachDraft:
         parsed = OutreachDraftEmailLLM.__new__(OutreachDraftEmailLLM)
         object.__setattr__(parsed, "draft_email", "   ")
         with patch(
-            "app.llm.outreach.service.huggingface_provider.generate_structured_output",
+            "app.llm.outreach.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ):
@@ -43,7 +43,7 @@ class TestGenerateBrokerOutreachDraft:
         parsed = OutreachDraftEmailLLM(draft_email="Dear Bob,\n\nI saw your listing and wanted to reach out.")
         profile = {"first_name": "Alice", "email": "alice@example.com"}
         with patch(
-            "app.llm.outreach.service.huggingface_provider.generate_structured_output",
+            "app.llm.outreach.service.generate_structured_output",
             new_callable=AsyncMock,
             return_value=parsed,
         ) as mock_gen:

--- a/backend/tests/llm/providers/test_chat.py
+++ b/backend/tests/llm/providers/test_chat.py
@@ -1,0 +1,96 @@
+"""Tests for chat provider resolution and facade."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from app.llm.providers.chat import (
+    generate_structured_output,
+    resolve_chat_provider,
+    resolve_chat_provider_name,
+)
+from app.llm.providers.huggingface import huggingface_provider
+from app.llm.providers.openrouter import openrouter_provider
+
+
+class _Schema(BaseModel):
+    text: str
+
+
+def _config(*, openrouter_api_key: str = "", hf_token: str = "") -> MagicMock:
+    mock = MagicMock()
+    mock.openrouter_api_key = openrouter_api_key
+    mock.hf_token = hf_token
+    return mock
+
+
+class TestResolveChatProviderName:
+    def test_openrouter_wins_when_both_keys_set(self):
+        config = _config(openrouter_api_key="or-key", hf_token="hf-key")
+        assert resolve_chat_provider_name(config=config) == "openrouter"
+
+    def test_huggingface_when_only_hf_token(self):
+        config = _config(hf_token="hf-key")
+        assert resolve_chat_provider_name(config=config) == "huggingface"
+
+    def test_openrouter_when_only_openrouter_key(self):
+        config = _config(openrouter_api_key="or-key")
+        assert resolve_chat_provider_name(config=config) == "openrouter"
+
+    def test_none_when_no_keys(self):
+        config = _config()
+        assert resolve_chat_provider_name(config=config) is None
+
+
+class TestResolveChatProvider:
+    def test_returns_openrouter_provider(self):
+        config = _config(openrouter_api_key="or-key")
+        assert resolve_chat_provider(config=config) is openrouter_provider
+
+    def test_returns_huggingface_provider(self):
+        config = _config(hf_token="hf-key")
+        assert resolve_chat_provider(config=config) is huggingface_provider
+
+    def test_raises_ai_unavailable_when_no_keys(self):
+        config = _config()
+        with pytest.raises(HTTPException) as info:
+            resolve_chat_provider(config=config)
+        assert info.value.status_code == 503
+        assert info.value.detail == "AI unavailable"
+
+
+class TestGenerateStructuredOutput:
+    async def test_delegates_to_resolved_provider(self):
+        parsed = _Schema(text="ok")
+        config = _config(openrouter_api_key="or-key")
+        with patch(
+            "app.llm.providers.chat.resolve_chat_provider",
+            return_value=MagicMock(
+                generate_structured_output=AsyncMock(return_value=parsed),
+            ),
+        ) as mock_resolve:
+            result = await generate_structured_output(
+                messages=[{"role": "user", "content": "hi"}],
+                response_format=_Schema,
+                temperature=0.1,
+                max_tokens=50,
+                config=config,
+            )
+        mock_resolve.assert_called_once_with(config=config)
+        assert result.text == "ok"
+
+    async def test_raises_ai_unavailable_without_keys(self):
+        config = _config()
+        with pytest.raises(HTTPException) as info:
+            await generate_structured_output(
+                messages=[{"role": "user", "content": "hi"}],
+                response_format=_Schema,
+                temperature=0.1,
+                max_tokens=50,
+                config=config,
+            )
+        assert info.value.status_code == 503
+        assert info.value.detail == "AI unavailable"

--- a/backend/tests/llm/providers/test_embeddings.py
+++ b/backend/tests/llm/providers/test_embeddings.py
@@ -1,0 +1,77 @@
+"""Tests for embeddings provider resolution and facade."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.llm.providers.embeddings import (
+    embed,
+    resolve_embeddings_provider,
+    resolve_embeddings_provider_name,
+)
+from app.llm.providers.huggingface import huggingface_provider
+from app.llm.providers.openrouter import openrouter_provider
+
+
+def _config(*, openrouter_api_key: str = "", hf_token: str = "") -> MagicMock:
+    mock = MagicMock()
+    mock.openrouter_api_key = openrouter_api_key
+    mock.hf_token = hf_token
+    return mock
+
+
+class TestResolveEmbeddingsProviderName:
+    def test_huggingface_wins_when_both_keys_set(self):
+        config = _config(openrouter_api_key="or-key", hf_token="hf-key")
+        assert resolve_embeddings_provider_name(config=config) == "huggingface"
+
+    def test_huggingface_when_only_hf_token(self):
+        config = _config(hf_token="hf-key")
+        assert resolve_embeddings_provider_name(config=config) == "huggingface"
+
+    def test_openrouter_when_only_openrouter_key(self):
+        config = _config(openrouter_api_key="or-key")
+        assert resolve_embeddings_provider_name(config=config) == "openrouter"
+
+    def test_none_when_no_keys(self):
+        config = _config()
+        assert resolve_embeddings_provider_name(config=config) is None
+
+
+class TestResolveEmbeddingsProvider:
+    def test_returns_huggingface_provider(self):
+        config = _config(hf_token="hf-key")
+        assert resolve_embeddings_provider(config=config) is huggingface_provider
+
+    def test_returns_openrouter_provider(self):
+        config = _config(openrouter_api_key="or-key")
+        assert resolve_embeddings_provider(config=config) is openrouter_provider
+
+    def test_raises_embeddings_unavailable_when_no_keys(self):
+        config = _config()
+        with pytest.raises(HTTPException) as info:
+            resolve_embeddings_provider(config=config)
+        assert info.value.status_code == 503
+        assert info.value.detail == "Embeddings unavailable"
+
+
+class TestEmbed:
+    async def test_delegates_to_resolved_provider(self):
+        vectors = [[0.1, 0.2], [0.3, 0.4]]
+        config = _config(hf_token="hf-key")
+        with patch(
+            "app.llm.providers.embeddings.resolve_embeddings_provider",
+            return_value=MagicMock(embed=AsyncMock(return_value=vectors)),
+        ) as mock_resolve:
+            result = await embed(texts=["a", "b"], config=config)
+        mock_resolve.assert_called_once_with(config=config)
+        assert result == vectors
+
+    async def test_raises_embeddings_unavailable_without_keys(self):
+        config = _config()
+        with pytest.raises(HTTPException) as info:
+            await embed(texts=["a"], config=config)
+        assert info.value.status_code == 503
+        assert info.value.detail == "Embeddings unavailable"

--- a/backend/tests/llm/providers/test_exceptions.py
+++ b/backend/tests/llm/providers/test_exceptions.py
@@ -4,12 +4,14 @@ from openai import APITimeoutError, OpenAIError
 from pydantic import ValidationError
 
 from app.llm.providers.exceptions import (
+    raise_ai_unavailable,
     raise_hf_api_key_not_configured,
     raise_hf_completion_parse_failed,
     raise_hf_openai_error,
     raise_hf_request_timeout,
     raise_hf_structured_refusal,
     raise_hf_structured_reply_incomplete,
+    raise_openrouter_api_key_not_configured,
 )
 
 
@@ -24,9 +26,20 @@ def _make_validation_error():
 
 
 class TestLlmProviderExceptions:
+    def test_ai_unavailable_raises_503(self):
+        with pytest.raises(HTTPException) as info:
+            raise_ai_unavailable()
+        assert info.value.status_code == 503
+        assert info.value.detail == "AI unavailable"
+
     def test_api_key_not_configured_raises_503(self):
         with pytest.raises(HTTPException) as info:
             raise_hf_api_key_not_configured()
+        assert info.value.status_code == 503
+
+    def test_openrouter_api_key_not_configured_raises_503(self):
+        with pytest.raises(HTTPException) as info:
+            raise_openrouter_api_key_not_configured()
         assert info.value.status_code == 503
 
     def test_completion_parse_failed_raises_502(self):

--- a/backend/tests/llm/providers/test_exceptions.py
+++ b/backend/tests/llm/providers/test_exceptions.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from app.llm.providers.exceptions import (
     raise_ai_unavailable,
+    raise_embeddings_unavailable,
     raise_hf_api_key_not_configured,
     raise_hf_completion_parse_failed,
     raise_hf_openai_error,
@@ -31,6 +32,12 @@ class TestLlmProviderExceptions:
             raise_ai_unavailable()
         assert info.value.status_code == 503
         assert info.value.detail == "AI unavailable"
+
+    def test_embeddings_unavailable_raises_503(self):
+        with pytest.raises(HTTPException) as info:
+            raise_embeddings_unavailable()
+        assert info.value.status_code == 503
+        assert info.value.detail == "Embeddings unavailable"
 
     def test_api_key_not_configured_raises_503(self):
         with pytest.raises(HTTPException) as info:

--- a/backend/tests/llm/providers/test_huggingface.py
+++ b/backend/tests/llm/providers/test_huggingface.py
@@ -21,6 +21,7 @@ def _make_provider(hf_token: str = "tok") -> HuggingFaceProvider:
     mock_settings = MagicMock()
     mock_settings.hf_token = hf_token
     mock_settings.hf_model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    mock_settings.hf_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
     mock_settings.hf_base_url = "https://router.huggingface.co/v1"
     mock_settings.hf_input_cost_per_1m = 0.2
     mock_settings.hf_output_cost_per_1m = 0.2
@@ -114,3 +115,27 @@ class TestHuggingFaceProvider:
                 messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
             )
         assert info.value.status_code == 502
+
+
+class TestHuggingFaceEmbed:
+    async def test_empty_texts_returns_empty_without_call(self):
+        provider = _make_provider()
+        provider.client.embeddings.create = AsyncMock()
+        result = await provider.embed(texts=[])
+        assert result == []
+        provider.client.embeddings.create.assert_not_called()
+
+    async def test_no_api_key_raises_503(self):
+        provider = _make_provider(hf_token="   ")
+        with pytest.raises(HTTPException) as info:
+            await provider.embed(texts=["hello"])
+        assert info.value.status_code == 503
+
+    async def test_success_returns_ordered_vectors(self):
+        provider = _make_provider()
+        item0 = MagicMock(index=1, embedding=[0.3, 0.4])
+        item1 = MagicMock(index=0, embedding=[0.1, 0.2])
+        response = MagicMock(data=[item0, item1], usage=None)
+        provider.client.embeddings.create = AsyncMock(return_value=response)
+        result = await provider.embed(texts=["a", "b"])
+        assert result == [[0.1, 0.2], [0.3, 0.4]]

--- a/backend/tests/llm/providers/test_huggingface.py
+++ b/backend/tests/llm/providers/test_huggingface.py
@@ -120,10 +120,10 @@ class TestHuggingFaceProvider:
 class TestHuggingFaceEmbed:
     async def test_empty_texts_returns_empty_without_call(self):
         provider = _make_provider()
-        provider.client.embeddings.create = AsyncMock()
-        result = await provider.embed(texts=[])
-        assert result == []
-        provider.client.embeddings.create.assert_not_called()
+        with patch("app.llm.providers.huggingface.httpx.AsyncClient") as client_cls:
+            result = await provider.embed(texts=[])
+            assert result == []
+            client_cls.assert_not_called()
 
     async def test_no_api_key_raises_503(self):
         provider = _make_provider(hf_token="   ")
@@ -131,11 +131,40 @@ class TestHuggingFaceEmbed:
             await provider.embed(texts=["hello"])
         assert info.value.status_code == 503
 
-    async def test_success_returns_ordered_vectors(self):
+    async def test_feature_extraction_url_strips_v1(self):
         provider = _make_provider()
-        item0 = MagicMock(index=1, embedding=[0.3, 0.4])
-        item1 = MagicMock(index=0, embedding=[0.1, 0.2])
-        response = MagicMock(data=[item0, item1], usage=None)
-        provider.client.embeddings.create = AsyncMock(return_value=response)
-        result = await provider.embed(texts=["a", "b"])
+        assert provider._feature_extraction_url() == (
+            "https://router.huggingface.co/hf-inference/models/"
+            "sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction"
+        )
+
+    async def test_success_returns_batch_vectors(self):
+        provider = _make_provider()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = MagicMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.llm.providers.huggingface.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.embed(texts=["a", "b"])
+
         assert result == [[0.1, 0.2], [0.3, 0.4]]
+        mock_client.post.assert_awaited_once()
+        args, kwargs = mock_client.post.await_args
+        assert args[0].endswith("/pipeline/feature-extraction")
+        assert kwargs["json"] == {"inputs": ["a", "b"]}
+
+    async def test_http_error_raises_502(self):
+        provider = _make_provider()
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+
+        with patch("app.llm.providers.huggingface.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(HTTPException) as info:
+                await provider.embed(texts=["hello"])
+        assert info.value.status_code == 502

--- a/backend/tests/llm/providers/test_huggingface.py
+++ b/backend/tests/llm/providers/test_huggingface.py
@@ -58,12 +58,16 @@ class TestHuggingFaceProvider:
             )
         assert info.value.status_code == 503
 
-    async def test_success_returns_parsed(self):
+    async def test_success_returns_parsed_json(self):
         provider = _make_provider()
-        parsed = _Schema(text="hello")
-        provider.client.beta.chat.completions.parse = AsyncMock(
-            return_value=_make_completion(parsed=parsed)
+        completion = MagicMock()
+        completion.usage = MagicMock(
+            prompt_tokens=10, completion_tokens=20, total_tokens=30
         )
+        completion.choices = [
+            MagicMock(message=MagicMock(content='{"text":"hello"}', refusal=None))
+        ]
+        provider.client.chat.completions.create = AsyncMock(return_value=completion)
         result = await provider.generate_structured_output(
             messages=_MESSAGES,
             response_format=_Schema,
@@ -71,10 +75,49 @@ class TestHuggingFaceProvider:
             max_tokens=100,
         )
         assert result.text == "hello"
+        kwargs = provider.client.chat.completions.create.await_args.kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert kwargs["messages"][0]["role"] == "system"
+        assert "JSON Schema" in kwargs["messages"][0]["content"]
+
+    async def test_retries_without_json_object_when_unsupported(self):
+        provider = _make_provider()
+        completion = MagicMock()
+        completion.usage = None
+        completion.choices = [
+            MagicMock(message=MagicMock(content='{"text":"ok"}', refusal=None))
+        ]
+        unsupported = OpenAIError("json_object unsupported")
+        unsupported.status_code = 422
+        provider.client.chat.completions.create = AsyncMock(
+            side_effect=[unsupported, completion]
+        )
+        result = await provider.generate_structured_output(
+            messages=_MESSAGES,
+            response_format=_Schema,
+            temperature=0.5,
+            max_tokens=100,
+        )
+        assert result.text == "ok"
+        assert provider.client.chat.completions.create.await_count == 2
+        second_kwargs = provider.client.chat.completions.create.await_args_list[1].kwargs
+        assert "response_format" not in second_kwargs
+
+    async def test_non_json_mode_errors_do_not_retry(self):
+        provider = _make_provider()
+        boom = OpenAIError("upstream down")
+        boom.status_code = 500
+        provider.client.chat.completions.create = AsyncMock(side_effect=boom)
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 502
+        assert provider.client.chat.completions.create.await_count == 1
 
     async def test_timeout_raises_504(self):
         provider = _make_provider()
-        provider.client.beta.chat.completions.parse = AsyncMock(
+        provider.client.chat.completions.create = AsyncMock(
             side_effect=APITimeoutError(request=httpx.Request("POST", "https://api.example.com"))
         )
         with pytest.raises(HTTPException) as info:
@@ -85,7 +128,7 @@ class TestHuggingFaceProvider:
 
     async def test_openai_error_raises_502(self):
         provider = _make_provider()
-        provider.client.beta.chat.completions.parse = AsyncMock(
+        provider.client.chat.completions.create = AsyncMock(
             side_effect=OpenAIError("upstream down")
         )
         with pytest.raises(HTTPException) as info:
@@ -96,9 +139,12 @@ class TestHuggingFaceProvider:
 
     async def test_refusal_raises_502(self):
         provider = _make_provider()
-        provider.client.beta.chat.completions.parse = AsyncMock(
-            return_value=_make_completion(parsed=None, refusal="I cannot help with that.")
-        )
+        completion = MagicMock()
+        completion.usage = None
+        completion.choices = [
+            MagicMock(message=MagicMock(content=None, refusal="I cannot help with that."))
+        ]
+        provider.client.chat.completions.create = AsyncMock(return_value=completion)
         with pytest.raises(HTTPException) as info:
             await provider.generate_structured_output(
                 messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
@@ -107,9 +153,24 @@ class TestHuggingFaceProvider:
 
     async def test_incomplete_reply_raises_502(self):
         provider = _make_provider()
-        provider.client.beta.chat.completions.parse = AsyncMock(
-            return_value=_make_completion(parsed=None, refusal=None)
-        )
+        completion = MagicMock()
+        completion.usage = None
+        completion.choices = [MagicMock(message=MagicMock(content="  ", refusal=None))]
+        provider.client.chat.completions.create = AsyncMock(return_value=completion)
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 502
+
+    async def test_invalid_json_raises_502(self):
+        provider = _make_provider()
+        completion = MagicMock()
+        completion.usage = None
+        completion.choices = [
+            MagicMock(message=MagicMock(content="not-json", refusal=None))
+        ]
+        provider.client.chat.completions.create = AsyncMock(return_value=completion)
         with pytest.raises(HTTPException) as info:
             await provider.generate_structured_output(
                 messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100

--- a/backend/tests/llm/providers/test_openrouter.py
+++ b/backend/tests/llm/providers/test_openrouter.py
@@ -20,6 +20,7 @@ def _make_provider(openrouter_api_key: str = "tok") -> OpenRouterProvider:
     mock_settings = MagicMock()
     mock_settings.openrouter_api_key = openrouter_api_key
     mock_settings.openrouter_chat_model = "meta-llama/llama-3.1-8b-instruct"
+    mock_settings.openrouter_embedding_model = "openai/text-embedding-3-small"
     mock_settings.openrouter_base_url = "https://openrouter.ai/api/v1"
     mock_settings.openrouter_http_referer = ""
     mock_settings.openrouter_app_title = "Real Estate Consultant"
@@ -115,3 +116,27 @@ class TestOpenRouterProvider:
                 messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
             )
         assert info.value.status_code == 502
+
+
+class TestOpenRouterEmbed:
+    async def test_empty_texts_returns_empty_without_call(self):
+        provider = _make_provider()
+        provider.client.embeddings.create = AsyncMock()
+        result = await provider.embed(texts=[])
+        assert result == []
+        provider.client.embeddings.create.assert_not_called()
+
+    async def test_no_api_key_raises_503(self):
+        provider = _make_provider(openrouter_api_key="   ")
+        with pytest.raises(HTTPException) as info:
+            await provider.embed(texts=["hello"])
+        assert info.value.status_code == 503
+
+    async def test_success_returns_ordered_vectors(self):
+        provider = _make_provider()
+        item0 = MagicMock(index=1, embedding=[0.3, 0.4])
+        item1 = MagicMock(index=0, embedding=[0.1, 0.2])
+        response = MagicMock(data=[item0, item1], usage=None)
+        provider.client.embeddings.create = AsyncMock(return_value=response)
+        result = await provider.embed(texts=["a", "b"])
+        assert result == [[0.1, 0.2], [0.3, 0.4]]

--- a/backend/tests/llm/providers/test_openrouter.py
+++ b/backend/tests/llm/providers/test_openrouter.py
@@ -1,0 +1,117 @@
+"""Tests for OpenRouterProvider.generate_structured_output."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from openai import APITimeoutError, OpenAIError
+from pydantic import BaseModel
+
+from app.llm.providers.openrouter import OpenRouterProvider
+
+
+class _Schema(BaseModel):
+    text: str
+
+
+def _make_provider(openrouter_api_key: str = "tok") -> OpenRouterProvider:
+    mock_settings = MagicMock()
+    mock_settings.openrouter_api_key = openrouter_api_key
+    mock_settings.openrouter_chat_model = "meta-llama/llama-3.1-8b-instruct"
+    mock_settings.openrouter_base_url = "https://openrouter.ai/api/v1"
+    mock_settings.openrouter_http_referer = ""
+    mock_settings.openrouter_app_title = "Real Estate Consultant"
+    mock_settings.openrouter_input_cost_per_1m = 0.2
+    mock_settings.openrouter_output_cost_per_1m = 0.2
+    mock_client = AsyncMock()
+    return OpenRouterProvider(settings=mock_settings, client=mock_client)
+
+
+def _make_completion(parsed=None, refusal=None):
+    msg = MagicMock()
+    msg.parsed = parsed
+    msg.refusal = refusal
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 20
+    usage.total_tokens = 30
+    completion = MagicMock()
+    completion.choices = [MagicMock(message=msg)]
+    completion.usage = usage
+    return completion
+
+
+_MESSAGES = [{"role": "user", "content": "Hello"}]
+
+
+class TestOpenRouterProvider:
+    async def test_no_api_key_raises_503(self):
+        provider = _make_provider(openrouter_api_key="   ")
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES,
+                response_format=_Schema,
+                temperature=0.5,
+                max_tokens=100,
+            )
+        assert info.value.status_code == 503
+
+    async def test_success_returns_parsed(self):
+        provider = _make_provider()
+        parsed = _Schema(text="hello")
+        provider.client.beta.chat.completions.parse = AsyncMock(
+            return_value=_make_completion(parsed=parsed)
+        )
+        result = await provider.generate_structured_output(
+            messages=_MESSAGES,
+            response_format=_Schema,
+            temperature=0.5,
+            max_tokens=100,
+        )
+        assert result.text == "hello"
+
+    async def test_timeout_raises_504(self):
+        provider = _make_provider()
+        provider.client.beta.chat.completions.parse = AsyncMock(
+            side_effect=APITimeoutError(request=httpx.Request("POST", "https://api.example.com"))
+        )
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 504
+
+    async def test_openai_error_raises_502(self):
+        provider = _make_provider()
+        provider.client.beta.chat.completions.parse = AsyncMock(
+            side_effect=OpenAIError("upstream down")
+        )
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 502
+
+    async def test_refusal_raises_502(self):
+        provider = _make_provider()
+        provider.client.beta.chat.completions.parse = AsyncMock(
+            return_value=_make_completion(parsed=None, refusal="I cannot help with that.")
+        )
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 502
+
+    async def test_incomplete_reply_raises_502(self):
+        provider = _make_provider()
+        provider.client.beta.chat.completions.parse = AsyncMock(
+            return_value=_make_completion(parsed=None, refusal=None)
+        )
+        with pytest.raises(HTTPException) as info:
+            await provider.generate_structured_output(
+                messages=_MESSAGES, response_format=_Schema, temperature=0.5, max_tokens=100
+            )
+        assert info.value.status_code == 502


### PR DESCRIPTION
## Summary
- Add dual chat LLM providers with a shared resolver: `OPENROUTER_API_KEY` prefers OpenRouter; otherwise `HF_TOKEN` uses Hugging Face; neither returns 503 `"AI unavailable"`. Intake, fit, and outreach all go through the resolver.
- Add embeddings with separate priority (`HF_TOKEN` preferred when both keys are set) plus HF feature-extraction (router `/v1` is chat-only) so embeddings work against Inference Providers.
- Harden HF structured chat: use JSON-object responses with local Pydantic validation to avoid flaky 422 grammar compilation on the HF router; document setup in backend/root READMEs and `.env.example`.

## Test plan
- [x] Backend: only `HF_TOKEN` → chat + embeddings use Hugging Face; intake/fit/outreach succeed
- [x] Backend: only `OPENROUTER_API_KEY` → chat + embeddings use OpenRouter
- [x] Backend: both keys → chat uses OpenRouter, embeddings use Hugging Face
- [x] Backend: neither key → chat returns 503 `"AI unavailable"`; embeddings return `"Embeddings unavailable"`
- [x] HF chat: intake `POST …/answers/llm` succeeds without 422 grammar errors
- [x] HF embeddings: `embed()` returns vectors via feature-extraction (not OpenAI `/v1/embeddings`)
- [x] Run `pytest` under `backend/tests/llm/providers/`