### PR TITLE
Keep the account sidebar visible across every account view

### DIFF
--- a/frontend/app/(landing)/listings/page.tsx
+++ b/frontend/app/(landing)/listings/page.tsx
@@ -1,72 +1,7 @@
-﻿"use client";
+"use client";
 
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import { ListingsIndexView } from "@components/listings/index-view";
 
-import { ButtonPrimary } from "@components/ui/button-primary";
-import { detailToModel } from "@components/property/listing-model";
-import type { PropertyModel } from "@typings/property";
-import { PropertyCard, PropertyCardSkeleton, PROPERTY_GRID } from "@components/property/card";
-import { Heading2 } from "@components/ui/heading2";
-import { brand } from "@config/brand";
-import { listingsService } from "@services/listings";
-import { PAGE_CONTAINER } from "@components/ui/styles";
-import { cn } from "@utils/common";
-
-const isCancellation = (err: unknown) =>
-  (err instanceof DOMException && err.name === "AbortError") ||
-  (err != null && typeof err === "object" && "code" in err && (err as { code: string }).code === "ERR_CANCELED");
-
-const ListingsIndexPage = () => {
-  const pathname = usePathname();
-  const [models, setModels] = useState<PropertyModel[] | null>(null);
-
-  useEffect(() => {
-    setModels(null);
-    const controller = new AbortController();
-    listingsService
-      .getFeaturedListings({ signal: controller.signal })
-      .then((res) => setModels(res.listings.map(detailToModel)))
-      .catch((err: unknown) => { if (!isCancellation(err)) setModels([]); });
-    return () => controller.abort();
-  }, [pathname]);
-
-  const loading = models === null;
-
-  return (
-    <div className={cn(PAGE_CONTAINER, "py-16 lg:py-20")}>
-      <div className="flex flex-col items-start gap-6 border-b border-neutral-200 pb-12 lg:flex-row lg:items-end lg:justify-between dark:border-neutral-700">
-        <div className="max-w-2xl">
-          <h1 className="text-3xl font-semibold text-neutral-900 md:text-4xl dark:text-neutral-100">
-            {brand.sections.listings.heading}
-          </h1>
-          <p className="mt-3 text-base text-neutral-500 md:text-lg dark:text-neutral-400">
-            {brand.sections.listings.subHeading} Start an AI-guided search to see properties
-            matched to your needs.
-          </p>
-        </div>
-        <ButtonPrimary href="/questionnaire" sizeClass="px-7 py-3.5" fontSize="text-base font-medium">
-          Start searching
-        </ButtonPrimary>
-      </div>
-
-      <section className="relative pt-12">
-        <Heading2
-          heading={brand.sections.featured.heading}
-          subHeading={
-            <span className="mt-3 block text-neutral-500 dark:text-neutral-400">
-              {brand.sections.featured.subHeading}
-            </span>
-          }
-        />
-        <div className={PROPERTY_GRID}>
-          {loading
-            ? Array.from({ length: 6 }).map((_, i) => <PropertyCardSkeleton key={i} />)
-            : models.map((item) => <PropertyCard key={item.id} data={item} />)}
-        </div>
-      </section>
-    </div>
-  );
-};
+const ListingsIndexPage = () => <ListingsIndexView />;
 
 export default ListingsIndexPage;

--- a/frontend/components/account/page.tsx
+++ b/frontend/components/account/page.tsx
@@ -25,6 +25,7 @@ import {
   type McpApiKeyCreated,
 } from "@services/account";
 
+import { ListingsIndexView } from "@components/listings/index-view";
 import { SavedView } from "@components/saved/view";
 
 import { AccountSidebar, type AccountTab } from "./sidebar";
@@ -50,6 +51,14 @@ export const AccountPage = () => {
   const { session, ready, refresh } = useAuth();
 
   const [activeTab, setActiveTab] = useState<AccountTab>("profile");
+  // The Saved tab's empty state can swap its panel for the listings index, so
+  // "Browse properties" doesn't navigate the sidebar away mid-flow.
+  const [browsingListings, setBrowsingListings] = useState(false);
+
+  const selectTab = useCallback((tab: AccountTab) => {
+    setActiveTab(tab);
+    setBrowsingListings(false);
+  }, []);
 
   const [savedProfile, setSavedProfile] = useState<ProfileFormValues>(emptyProfile);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -451,7 +460,7 @@ export const AccountPage = () => {
 
   return (
     <div className="flex flex-col lg:flex-row">
-      <AccountSidebar activeTab={activeTab} onSelectTab={setActiveTab} />
+      <AccountSidebar activeTab={activeTab} onSelectTab={selectTab} />
 
       <main className="min-w-0 flex-1 px-3 py-8 lg:px-6">
         {/* One width for every tab: a per-tab cap made the card jump on switch.
@@ -518,7 +527,13 @@ export const AccountPage = () => {
             />
           ) : null}
 
-          {activeTab === "saved" ? <SavedView embedded /> : null}
+          {activeTab === "saved" ? (
+            browsingListings ? (
+              <ListingsIndexView embedded onBack={() => setBrowsingListings(false)} />
+            ) : (
+              <SavedView embedded onBrowse={() => setBrowsingListings(true)} />
+            )
+          ) : null}
         </div>
       </main>
 

--- a/frontend/components/account/page.tsx
+++ b/frontend/components/account/page.tsx
@@ -25,6 +25,8 @@ import {
   type McpApiKeyCreated,
 } from "@services/account";
 
+import { SavedView } from "@components/saved/view";
+
 import { AccountSidebar, type AccountTab } from "./sidebar";
 import { AccountApiKeysSection } from "./sections/api-keys";
 import { ApiKeyCreatedDialog } from "./sections/api-keys/created-dialog";
@@ -474,7 +476,9 @@ export const AccountPage = () => {
               onSave={saveProfile}
               onChangeField={updateDraft}
             />
-          ) : activeTab === "security" ? (
+          ) : null}
+
+          {activeTab === "security" ? (
             <AccountPasswordSection
               currentPassword={currentPassword}
               newPassword={newPassword}
@@ -487,7 +491,9 @@ export const AccountPage = () => {
               onChangeConfirm={onChangeConfirmPassword}
               onSubmit={submitPasswordChange}
             />
-          ) : (
+          ) : null}
+
+          {activeTab === "api-keys" ? (
             <AccountApiKeysSection
               keys={apiKeys}
               loading={apiKeysLoading}
@@ -510,7 +516,9 @@ export const AccountPage = () => {
               onConfirmRevoke={confirmRevokeApiKey}
               onCancelRevoke={() => setConfirmingRevokeId(null)}
             />
-          )}
+          ) : null}
+
+          {activeTab === "saved" ? <SavedView embedded /> : null}
         </div>
       </main>
 

--- a/frontend/components/account/sidebar.tsx
+++ b/frontend/components/account/sidebar.tsx
@@ -8,11 +8,16 @@ import { useAuth } from "@contexts/auth";
 import { cn } from "@utils/common";
 
 /**
- * Voyager `AccountSidebar` adapted to this app: dark workspace rail with the
+ * Voyager `AccountSidebar` adapted to this app: a workspace rail with the
  * signed-in user's avatar and a tabbed nav for the account sections. Branding
  * is left to the site header above it. Every entry is an in-page tab that
  * swaps the visible panel — Saved included, so the rail survives the click.
  * The standalone `/saved` route still serves the links in the site header.
+ *
+ * The rail follows the theme toggle rather than staying dark in both: it sits
+ * flush against the header, and a permanently-dark rail under a white header
+ * read as a rendering bug. Light mode lifts off the white canvas with a
+ * neutral-50 surface; the original dark values live on under `dark:`.
  */
 export type AccountTab = "profile" | "security" | "api-keys" | "saved";
 
@@ -50,7 +55,19 @@ const TAB_ITEMS: {
 
 const ITEM_CLASS =
   "group flex flex-shrink-0 items-center gap-3 rounded-lg border-l-2 px-3 py-3 text-left transition-colors";
-const DESCRIPTION = "hidden text-xs text-neutral-500 group-hover:text-neutral-400 lg:block";
+const DESCRIPTION = cn(
+  "hidden text-xs text-neutral-500 group-hover:text-neutral-600 lg:block",
+  "dark:group-hover:text-neutral-400",
+);
+
+const ITEM_ACTIVE = cn(
+  "border-primary-500 bg-neutral-100 text-neutral-900",
+  "dark:bg-neutral-900 dark:text-white",
+);
+const ITEM_INACTIVE = cn(
+  "border-transparent text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900",
+  "dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-neutral-100",
+);
 
 type AccountSidebarProps = {
   activeTab: AccountTab;
@@ -63,8 +80,13 @@ export const AccountSidebar = ({ activeTab, onSelectTab }: AccountSidebarProps) 
   const avatarUrl = session?.user.avatarUrl?.trim() || undefined;
 
   return (
-    <aside className="flex-shrink-0 bg-neutral-950 text-neutral-200 lg:min-h-[calc(100vh-5rem)] lg:w-72">
-      <div className="hidden border-b border-neutral-800 px-6 py-6 lg:block">
+    <aside
+      className={cn(
+        "flex-shrink-0 border-neutral-200 bg-neutral-50 text-neutral-700 lg:min-h-[calc(100vh-5rem)] lg:w-72 lg:border-r",
+        "dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200",
+      )}
+    >
+      <div className="hidden border-b border-neutral-200 px-6 py-6 lg:block dark:border-neutral-800">
         <div className="flex items-center gap-3">
           <Avatar
             sizeClass="w-11 h-11"
@@ -75,7 +97,9 @@ export const AccountSidebar = ({ activeTab, onSelectTab }: AccountSidebarProps) 
             unoptimized
           />
           <div className="min-w-0">
-            <p className="truncate font-medium text-white">{email || "Your account"}</p>
+            <p className="truncate font-medium text-neutral-900 dark:text-white">
+              {email || "Your account"}
+            </p>
             <p className="truncate text-xs text-neutral-500">{brand.account.workspaceLabel}</p>
           </div>
         </div>
@@ -93,17 +117,14 @@ export const AccountSidebar = ({ activeTab, onSelectTab }: AccountSidebarProps) 
               type="button"
               onClick={() => onSelectTab(tab)}
               aria-current={active ? "page" : undefined}
-              className={cn(
-                ITEM_CLASS,
-                active
-                  ? "border-primary-500 bg-neutral-900 text-white"
-                  : "border-transparent text-neutral-400 hover:bg-neutral-900 hover:text-neutral-100",
-              )}
+              className={cn(ITEM_CLASS, active ? ITEM_ACTIVE : ITEM_INACTIVE)}
             >
               <Icon
                 className={cn(
                   "size-5 flex-shrink-0",
-                  active ? "text-primary-400" : "text-neutral-500 group-hover:text-primary-400",
+                  active
+                    ? "text-primary-600 dark:text-primary-400"
+                    : "text-neutral-400 group-hover:text-primary-600 dark:text-neutral-500 dark:group-hover:text-primary-400",
                 )}
                 aria-hidden
               />

--- a/frontend/components/account/sidebar.tsx
+++ b/frontend/components/account/sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { Heart, KeyRound, Plug, UserCircle } from "lucide-react";
 
 import { Avatar } from "@components/ui/avatar";
@@ -11,11 +10,11 @@ import { cn } from "@utils/common";
 /**
  * Voyager `AccountSidebar` adapted to this app: dark workspace rail with the
  * signed-in user's avatar and a tabbed nav for the account sections. Branding
- * is left to the site header above it. Profile + Security + API keys are
- * in-page tabs (switch the visible panel); Saved is a real route since it
- * lives on its own page.
+ * is left to the site header above it. Every entry is an in-page tab that
+ * swaps the visible panel — Saved included, so the rail survives the click.
+ * The standalone `/saved` route still serves the links in the site header.
  */
-export type AccountTab = "profile" | "security" | "api-keys";
+export type AccountTab = "profile" | "security" | "api-keys" | "saved";
 
 const TAB_ITEMS: {
   tab: AccountTab;
@@ -40,6 +39,12 @@ const TAB_ITEMS: {
     label: "API keys",
     description: "Connect AI tools to your account",
     icon: Plug,
+  },
+  {
+    tab: "saved",
+    label: "Saved",
+    description: "Properties you’ve saved",
+    icon: Heart,
   },
 ];
 
@@ -111,22 +116,6 @@ export const AccountSidebar = ({ activeTab, onSelectTab }: AccountSidebarProps) 
             </button>
           );
         })}
-
-        <Link
-          href="/saved"
-          className={cn(ITEM_CLASS, "border-transparent text-neutral-400 hover:bg-neutral-900 hover:text-neutral-100")}
-        >
-          <Heart
-            className="size-5 flex-shrink-0 text-neutral-500 group-hover:text-primary-400"
-            aria-hidden
-          />
-          <span className="min-w-0">
-            <span className="block text-sm font-medium">Saved</span>
-            <span className={DESCRIPTION}>
-              Properties you&rsquo;ve saved
-            </span>
-          </span>
-        </Link>
       </nav>
     </aside>
   );

--- a/frontend/components/listings/index-view.tsx
+++ b/frontend/components/listings/index-view.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { ButtonPrimary } from "@components/ui/button-primary";
+import { detailToModel } from "@components/property/listing-model";
+import type { PropertyModel } from "@typings/property";
+import { PropertyCard, PropertyCardSkeleton, PROPERTY_GRID } from "@components/property/card";
+import { Heading2 } from "@components/ui/heading2";
+import { brand } from "@config/brand";
+import { listingsService } from "@services/listings";
+import { PAGE_CONTAINER } from "@components/ui/styles";
+import { cn } from "@utils/common";
+
+const isCancellation = (err: unknown) =>
+  (err instanceof DOMException && err.name === "AbortError") ||
+  (err != null && typeof err === "object" && "code" in err && (err as { code: string }).code === "ERR_CANCELED");
+
+export type ListingsIndexViewProps = {
+  /**
+   * Rendered inside the account shell rather than as the `/listings` page. The
+   * shell already supplies the page container, width cap and vertical rhythm,
+   * so the standalone spacing would stack on top of it.
+   */
+  embedded?: boolean;
+  /**
+   * Shown as a back affordance when the view is reached from somewhere that
+   * can return to it — the account Saved tab's empty state, today. Without it
+   * an embedded view is a one-way trip out of whatever opened it.
+   */
+  onBack?: () => void;
+};
+
+/**
+ * The `/listings` index: intro + "Start searching" CTA over the featured grid.
+ *
+ * Extracted from the route so the account shell can render it in-panel — the
+ * Saved tab's empty state sends users here, and navigating to the real route
+ * would drop the account sidebar mid-flow.
+ */
+export const ListingsIndexView = ({ embedded = false, onBack }: ListingsIndexViewProps) => {
+  const pathname = usePathname();
+  const [models, setModels] = useState<PropertyModel[] | null>(null);
+
+  useEffect(() => {
+    setModels(null);
+    const controller = new AbortController();
+    listingsService
+      .getFeaturedListings({ signal: controller.signal })
+      .then((res) => setModels(res.listings.map(detailToModel)))
+      .catch((err: unknown) => { if (!isCancellation(err)) setModels([]); });
+    return () => controller.abort();
+  }, [pathname]);
+
+  const loading = models === null;
+
+  return (
+    <div className={embedded ? undefined : cn(PAGE_CONTAINER, "py-16 lg:py-20")}>
+      {onBack ? (
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-6 inline-flex cursor-pointer items-center gap-2 text-sm font-medium text-neutral-500 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+        >
+          <ArrowLeft className="size-4" aria-hidden />
+          Back to saved properties
+        </button>
+      ) : null}
+
+      <div className="flex flex-col items-start gap-6 border-b border-neutral-200 pb-12 lg:flex-row lg:items-end lg:justify-between dark:border-neutral-700">
+        <div className="max-w-2xl">
+          <h1
+            className={cn(
+              "font-semibold text-neutral-900 dark:text-neutral-100",
+              embedded ? "text-2xl" : "text-3xl md:text-4xl",
+            )}
+          >
+            {brand.sections.listings.heading}
+          </h1>
+          <p className="mt-3 text-base text-neutral-500 md:text-lg dark:text-neutral-400">
+            {brand.sections.listings.subHeading} Start an AI-guided search to see properties
+            matched to your needs.
+          </p>
+        </div>
+        <ButtonPrimary href="/questionnaire" sizeClass="px-7 py-3.5" fontSize="text-base font-medium">
+          Start searching
+        </ButtonPrimary>
+      </div>
+
+      <section className="relative pt-12">
+        <Heading2
+          heading={brand.sections.featured.heading}
+          subHeading={
+            <span className="mt-3 block text-neutral-500 dark:text-neutral-400">
+              {brand.sections.featured.subHeading}
+            </span>
+          }
+        />
+        <div className={PROPERTY_GRID}>
+          {loading
+            ? Array.from({ length: 6 }).map((_, i) => <PropertyCardSkeleton key={i} />)
+            : models.map((item) => <PropertyCard key={item.id} data={item} />)}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/frontend/components/saved/view.tsx
+++ b/frontend/components/saved/view.tsx
@@ -16,7 +16,16 @@ import { listingsService } from "@services/listings";
 import { PAGE_CONTAINER } from "@components/ui/styles";
 import { cn } from "@utils/common";
 
-export const SavedView = () => {
+export type SavedViewProps = {
+  /**
+   * Rendered inside the account shell rather than as the `/saved` page. The
+   * shell already supplies the page container, width cap and vertical rhythm,
+   * so the standalone spacing would stack on top of it.
+   */
+  embedded?: boolean;
+};
+
+export const SavedView = ({ embedded = false }: SavedViewProps) => {
   const { savedIds, isSaved, ready, signedIn } = useSavedListings();
   const [models, setModels] = useState<PropertyModel[] | null>(null);
 
@@ -56,9 +65,14 @@ export const SavedView = () => {
   const visible = (models ?? []).filter((m) => isSaved(m.id));
 
   return (
-    <div className={cn(PAGE_CONTAINER, "py-16 lg:py-20")}>
+    <div className={embedded ? undefined : cn(PAGE_CONTAINER, "py-16 lg:py-20")}>
       <div className="max-w-2xl">
-        <h1 className="text-3xl font-semibold text-neutral-900 md:text-4xl dark:text-neutral-100">
+        <h1
+          className={cn(
+            "font-semibold text-neutral-900 dark:text-neutral-100",
+            embedded ? "text-2xl" : "text-3xl md:text-4xl",
+          )}
+        >
           Saved properties
         </h1>
         <p className="mt-3 text-neutral-500 dark:text-neutral-400">

--- a/frontend/components/saved/view.tsx
+++ b/frontend/components/saved/view.tsx
@@ -23,9 +23,15 @@ export type SavedViewProps = {
    * so the standalone spacing would stack on top of it.
    */
   embedded?: boolean;
+  /**
+   * Handles the empty state's "Browse properties" CTA in place of navigating
+   * to `/listings`. The account shell passes one so browsing stays in-panel
+   * and keeps its sidebar; the standalone page leaves it unset and links out.
+   */
+  onBrowse?: () => void;
 };
 
-export const SavedView = ({ embedded = false }: SavedViewProps) => {
+export const SavedView = ({ embedded = false, onBrowse }: SavedViewProps) => {
   const { savedIds, isSaved, ready, signedIn } = useSavedListings();
   const [models, setModels] = useState<PropertyModel[] | null>(null);
 
@@ -110,7 +116,11 @@ export const SavedView = ({ embedded = false }: SavedViewProps) => {
             to save it here.
           </p>
           <div className="mt-6 flex justify-center">
-            <ButtonPrimary href="/listings">Browse properties</ButtonPrimary>
+            {onBrowse ? (
+              <ButtonPrimary onClick={onBrowse}>Browse properties</ButtonPrimary>
+            ) : (
+              <ButtonPrimary href="/listings">Browse properties</ButtonPrimary>
+            )}
           </div>
         </NoticeCard>
       ) : null}

--- a/frontend/tests/components/account/page.test.tsx
+++ b/frontend/tests/components/account/page.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AccountPage } from "@components/account/page";
 
@@ -25,6 +25,12 @@ vi.mock("@services/account", () => ({
 vi.mock("@lib/auth-session", () => ({
   readSession: () => null,
   saveSession: vi.fn(),
+}));
+vi.mock("@components/saved/provider", () => ({
+  useSavedListings: () => ({ savedIds: [], isSaved: () => false, ready: true, signedIn: true }),
+}));
+vi.mock("@services/listings", () => ({
+  listingsService: { getListing: vi.fn() },
 }));
 
 beforeEach(() => {
@@ -55,5 +61,16 @@ describe("AccountPage", () => {
     mockUseAuth.mockReturnValue({ session: { user: { email: "jane@test.com", avatarUrl: null } }, ready: true, refresh: vi.fn() });
     render(<AccountPage />);
     await waitFor(() => expect(screen.getByRole("navigation", { name: /account navigation/i })).toBeInTheDocument());
+  });
+
+  it("shows saved properties in-panel and keeps the sidebar", async () => {
+    mockUseAuth.mockReturnValue({ session: { user: { email: "jane@test.com", avatarUrl: null } }, ready: true, refresh: vi.fn() });
+    render(<AccountPage />);
+    const nav = await screen.findByRole("navigation", { name: /account navigation/i });
+
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+
+    expect(await screen.findByRole("heading", { name: /saved properties/i })).toBeInTheDocument();
+    expect(nav).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/account/page.test.tsx
+++ b/frontend/tests/components/account/page.test.tsx
@@ -5,6 +5,7 @@ import { AccountPage } from "@components/account/page";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/account",
 }));
 vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
@@ -30,7 +31,10 @@ vi.mock("@components/saved/provider", () => ({
   useSavedListings: () => ({ savedIds: [], isSaved: () => false, ready: true, signedIn: true }),
 }));
 vi.mock("@services/listings", () => ({
-  listingsService: { getListing: vi.fn() },
+  listingsService: {
+    getListing: vi.fn(),
+    getFeaturedListings: vi.fn().mockResolvedValue({ listings: [] }),
+  },
 }));
 
 beforeEach(() => {
@@ -72,5 +76,45 @@ describe("AccountPage", () => {
 
     expect(await screen.findByRole("heading", { name: /saved properties/i })).toBeInTheDocument();
     expect(nav).toBeInTheDocument();
+  });
+
+  it("keeps the sidebar when browsing properties from the empty Saved tab", async () => {
+    mockUseAuth.mockReturnValue({ session: { user: { email: "jane@test.com", avatarUrl: null } }, ready: true, refresh: vi.fn() });
+    render(<AccountPage />);
+    const nav = await screen.findByRole("navigation", { name: /account navigation/i });
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+
+    // The CTA must act in-panel, not navigate to /listings and drop the rail.
+    const browse = await screen.findByRole("button", { name: /browse properties/i });
+    fireEvent.click(browse);
+
+    expect(await screen.findByRole("button", { name: /back to saved properties/i })).toBeInTheDocument();
+    expect(nav).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /saved properties/i })).not.toBeInTheDocument();
+  });
+
+  it("returns to the saved list from the browse panel", async () => {
+    mockUseAuth.mockReturnValue({ session: { user: { email: "jane@test.com", avatarUrl: null } }, ready: true, refresh: vi.fn() });
+    render(<AccountPage />);
+    await screen.findByRole("navigation", { name: /account navigation/i });
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /browse properties/i }));
+
+    fireEvent.click(await screen.findByRole("button", { name: /back to saved properties/i }));
+
+    expect(await screen.findByRole("heading", { name: /saved properties/i })).toBeInTheDocument();
+  });
+
+  it("drops the browse panel when another tab is selected", async () => {
+    mockUseAuth.mockReturnValue({ session: { user: { email: "jane@test.com", avatarUrl: null } }, ready: true, refresh: vi.fn() });
+    render(<AccountPage />);
+    await screen.findByRole("navigation", { name: /account navigation/i });
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /browse properties/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /security/i }));
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+
+    expect(await screen.findByRole("heading", { name: /saved properties/i })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/account/sidebar.test.tsx
+++ b/frontend/tests/components/account/sidebar.test.tsx
@@ -3,12 +3,6 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AccountSidebar } from "@components/account/sidebar";
 
-vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
-
 vi.mock("next/image", () => ({
   default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
 }));
@@ -41,9 +35,12 @@ describe("AccountSidebar", () => {
     expect(onSelectTab).toHaveBeenCalledWith("security");
   });
 
-  it("renders the saved properties link", () => {
-    render(<AccountSidebar activeTab="profile" onSelectTab={vi.fn()} />);
-    expect(screen.getByRole("link", { name: /saved/i })).toHaveAttribute("href", "/saved");
+  it("keeps saved properties in-page so the sidebar survives the click", () => {
+    const onSelectTab = vi.fn();
+    render(<AccountSidebar activeTab="profile" onSelectTab={onSelectTab} />);
+    expect(screen.queryByRole("link", { name: /saved/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /saved/i }));
+    expect(onSelectTab).toHaveBeenCalledWith("saved");
   });
 
   it("shows user email when signed in", () => {

--- a/frontend/tests/components/account/sidebar.test.tsx
+++ b/frontend/tests/components/account/sidebar.test.tsx
@@ -47,4 +47,27 @@ describe("AccountSidebar", () => {
     render(<AccountSidebar activeTab="profile" onSelectTab={vi.fn()} />);
     expect(screen.getByText("user@test.com")).toBeInTheDocument();
   });
+
+  // The rail used to hardcode its dark palette, so the header's theme toggle
+  // flipped every surface around it and left the sidebar dark.
+  it("pairs every rail surface color with a dark: variant", () => {
+    const { container } = render(<AccountSidebar activeTab="profile" onSelectTab={vi.fn()} />);
+    const surfaces = [
+      container.querySelector("aside"),
+      ...container.querySelectorAll("nav button"),
+    ];
+
+    for (const el of surfaces) {
+      const classes = (el?.className ?? "").split(/\s+/);
+      // Every base surface property the rail paints must have a dark override,
+      // whatever shade that override picks.
+      const properties = new Set(
+        classes.flatMap((c) => (/^(bg|text)-/.test(c) ? [c.split("-")[0]] : [])),
+      );
+      expect(properties.size).toBeGreaterThan(0);
+      for (const property of properties) {
+        expect(classes.some((c) => c.startsWith(`dark:${property}-`))).toBe(true);
+      }
+    }
+  });
 });

--- a/frontend/tests/components/saved/view.test.tsx
+++ b/frontend/tests/components/saved/view.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SavedView } from "@components/saved/view";
 
@@ -41,6 +41,16 @@ describe("SavedView", () => {
     render(<SavedView />);
     expect(screen.getByText(/haven.*t saved any/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /browse properties/i })).toHaveAttribute("href", "/listings");
+  });
+
+  it("calls onBrowse instead of linking out when the account shell supplies one", () => {
+    const onBrowse = vi.fn();
+    mockUseSaved.mockReturnValue({ savedIds: [], isSaved: () => false, ready: true, signedIn: true });
+    render(<SavedView embedded onBrowse={onBrowse} />);
+
+    expect(screen.queryByRole("link", { name: /browse properties/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /browse properties/i }));
+    expect(onBrowse).toHaveBeenCalledOnce();
   });
 
   it("renders heading", () => {


### PR DESCRIPTION
## Summary

Three related fixes to `/account`, where the sidebar either vanished or stopped
responding to the theme toggle. Each one is its own commit.

## Problems

1. **Saved dropped the sidebar.** `Saved` was a `<Link href="/saved">`, and
   `/saved` lives in the `(landing)` route group — which renders no account
   rail. Clicking it in the sidebar navigated the sidebar away.
2. **The rail ignored the theme toggle.** It hardcoded `bg-neutral-950` /
   `border-neutral-800` / `bg-neutral-900` with no `dark:` variants, so flipping
   the header switch lit up the header and content cards and left the sidebar
   dark against them.
3. **"Browse properties" dropped it again.** The Saved empty state's CTA linked
   to `/listings`, so the click meant to rescue an empty Saved tab threw the
   sidebar away too.

## Changes

- `AccountTab` gains `"saved"`; the Heart entry moves into `TAB_ITEMS` and swaps
  the panel like the other three instead of navigating.
- Every rail surface pairs a light value with the original dark one under
  `dark:`. Light mode uses a `neutral-50` rail with a right border to stay
  distinct from the white canvas; active/hover states darken rather than
  lighten, hence the split into `ITEM_ACTIVE` / `ITEM_INACTIVE`.
- The `/listings` index is extracted out of its route into `ListingsIndexView`
  so the account shell can render it embedded. `SavedView` gains an optional
  `onBrowse` that swaps the panel instead of navigating, plus a back control;
  selecting another tab clears the browse panel so Saved reopens on the list.
- `SavedView` and `ListingsIndexView` share an `embedded` prop that defers
  container, width cap and vertical rhythm to whichever shell hosts them.

The standalone `/saved` and `/listings` routes are unchanged — the site header
dropdown and mobile nav still reach them, and `app/(landing)/listings/page.tsx`
is now a thin wrapper over the extracted view.

## Testing

Full frontend suite green: 877 tests across 113 files. New coverage for the
sidebar surviving a Saved click, the in-panel browse, the back control, the
tab-switch reset, that the standalone `/saved` page still links out, and a
guard asserting every `bg-`/`text-` utility on the rail has a `dark:` override
so the theme regression can't come back silently.