### PR TITLE
Fix surface the real reason an OAuth callback failed

### DIFF
--- a/frontend/app/(auth)/auth/callback/route.ts
+++ b/frontend/app/(auth)/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 
 import type { StoredSession } from "@lib/auth-session";
 import { syncProfileNamesAfterOAuth } from "@lib/oauth-profile-sync";
@@ -7,10 +8,47 @@ import { getSupabaseServerClient } from "@lib/supabase-server";
 const APP_SESSION_COOKIE = "radestate.session";
 const ONE_WEEK_SECONDS = 60 * 60 * 24 * 7;
 
-const buildSignInErrorUrl = (origin: string, message: string) => {
+/**
+ * Everything `@supabase/ssr` writes is prefixed `sb-<project-ref>-`: the PKCE
+ * `-code-verifier`, the `-auth-token` and its `.0`/`.1` size chunks.
+ */
+const SUPABASE_COOKIE_PREFIX = "sb-";
+
+/** Why the callback bailed. Echoed to the URL so a failure can be reported
+ *  from the address bar without digging through function logs. */
+type FailureReason = "missing_code" | "exchange_failed" | "no_refresh_token" | "unexpected";
+
+const buildSignInErrorUrl = (origin: string, message: string, reason: FailureReason) => {
   const url = new URL("/sign-in", origin);
   url.searchParams.set("oauth_error", message);
+  url.searchParams.set("oauth_reason", reason);
   return url;
+};
+
+/**
+ * A failed exchange leaves the PKCE verifier — and any half-written session
+ * chunks — behind. The next attempt then starts against state that cannot
+ * match its freshly minted code, so clear the slate on the way out and let the
+ * retry begin from nothing.
+ */
+const clearSupabaseAuthCookies = async (response: NextResponse) => {
+  const store = await cookies();
+  for (const { name } of store.getAll()) {
+    if (name.startsWith(SUPABASE_COOKIE_PREFIX)) {
+      response.cookies.set(name, "", { path: "/", maxAge: 0 });
+    }
+  }
+};
+
+const failSignIn = async (origin: string, reason: FailureReason, detail?: string) => {
+  console.error(`[oauth] callback failed (${reason})${detail ? `: ${detail}` : ""}`);
+  const message =
+    reason === "missing_code"
+      ? "Missing OAuth code. Try signing in again."
+      : "Sign-in failed. Please try again.";
+  const response = NextResponse.redirect(buildSignInErrorUrl(origin, message, reason));
+  await clearSupabaseAuthCookies(response);
+  return response;
 };
 
 export async function GET(request: Request) {
@@ -23,22 +61,21 @@ export async function GET(request: Request) {
       : "/";
 
   if (!code) {
-    return NextResponse.redirect(
-      buildSignInErrorUrl(requestUrl.origin, "Missing OAuth code. Try signing in again."),
-    );
+    return failSignIn(requestUrl.origin, "missing_code");
   }
 
   try {
     const supabase = await getSupabaseServerClient();
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
-    if (error || !data.session?.refresh_token) {
-      if (error) {
-        console.error("[oauth] exchangeCodeForSession failed:", error.message);
-      }
-      return NextResponse.redirect(
-        buildSignInErrorUrl(requestUrl.origin, "Sign-in failed. Please try again."),
-      );
+    if (error) {
+      return failSignIn(requestUrl.origin, "exchange_failed", error.message);
+    }
+
+    if (!data.session?.refresh_token) {
+      // Previously silent: the exchange reports success but hands back no
+      // refresh token, and the user saw the same message as a hard failure.
+      return failSignIn(requestUrl.origin, "no_refresh_token");
     }
 
     await syncProfileNamesAfterOAuth(supabase, data.session.user);
@@ -62,9 +99,10 @@ export async function GET(request: Request) {
     });
     return response;
   } catch (err) {
-    console.error("[oauth] callback failed:", err instanceof Error ? err.message : String(err));
-    return NextResponse.redirect(
-      buildSignInErrorUrl(requestUrl.origin, "Sign-in failed. Please try again."),
+    return failSignIn(
+      requestUrl.origin,
+      "unexpected",
+      err instanceof Error ? err.message : String(err),
     );
   }
 }

--- a/frontend/tests/app/auth-callback.test.ts
+++ b/frontend/tests/app/auth-callback.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { GET } from "../../app/(auth)/auth/callback/route";
+
+const mockExchange = vi.fn();
+const mockCookieStore = { getAll: vi.fn() };
+
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve(mockCookieStore),
+}));
+
+vi.mock("@lib/supabase-server", () => ({
+  getSupabaseServerClient: () =>
+    Promise.resolve({ auth: { exchangeCodeForSession: (code: string) => mockExchange(code) } }),
+}));
+
+vi.mock("@lib/oauth-profile-sync", () => ({
+  syncProfileNamesAfterOAuth: vi.fn().mockResolvedValue(undefined),
+}));
+
+const CALLBACK = "https://app.test/auth/callback";
+
+const session = (overrides: Record<string, unknown> = {}) => ({
+  access_token: "at",
+  refresh_token: "rt",
+  token_type: "bearer",
+  user: { id: "u1", email: "jane@test.com" },
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  console.error = vi.fn();
+  // The stale PKCE verifier a failed attempt would otherwise leave behind.
+  mockCookieStore.getAll.mockReturnValue([
+    { name: "sb-abc-auth-token-code-verifier", value: "v" },
+    { name: "sb-abc-auth-token.0", value: "chunk" },
+    { name: "radestate.session", value: "keep-me" },
+  ]);
+});
+
+/** Cookie name -> the raw Set-Cookie line, for max-age assertions. */
+const setCookies = (res: Response) =>
+  res.headers.getSetCookie().reduce<Record<string, string>>((acc, line) => {
+    acc[line.split("=")[0]] = line;
+    return acc;
+  }, {});
+
+describe("auth callback route", () => {
+  it("stores the session and redirects home on success", async () => {
+    mockExchange.mockResolvedValue({ data: { session: session() }, error: null });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+
+    expect(res.headers.get("location")).toBe("https://app.test/");
+    expect(setCookies(res)["radestate.session"]).toBeDefined();
+  });
+
+  it("honours a relative next path", async () => {
+    mockExchange.mockResolvedValue({ data: { session: session() }, error: null });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc&next=%2Faccount`));
+
+    expect(res.headers.get("location")).toBe("https://app.test/account");
+  });
+
+  it("rejects an absolute next path", async () => {
+    mockExchange.mockResolvedValue({ data: { session: session() }, error: null });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc&next=%2F%2Fevil.test`));
+
+    expect(res.headers.get("location")).toBe("https://app.test/");
+  });
+
+  it("reports the reason when the exchange errors", async () => {
+    mockExchange.mockResolvedValue({ data: {}, error: { message: "bad verifier" } });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+    const location = new URL(res.headers.get("location") ?? "");
+
+    expect(location.pathname).toBe("/sign-in");
+    expect(location.searchParams.get("oauth_reason")).toBe("exchange_failed");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("bad verifier"));
+  });
+
+  // Previously this branch returned the generic error and logged nothing at all.
+  it("reports a missing refresh token instead of failing silently", async () => {
+    mockExchange.mockResolvedValue({
+      data: { session: session({ refresh_token: undefined }) },
+      error: null,
+    });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+    const location = new URL(res.headers.get("location") ?? "");
+
+    expect(location.searchParams.get("oauth_reason")).toBe("no_refresh_token");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("no_refresh_token"));
+  });
+
+  it("reports an unexpected throw", async () => {
+    mockExchange.mockRejectedValue(new Error("boom"));
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+    const location = new URL(res.headers.get("location") ?? "");
+
+    expect(location.searchParams.get("oauth_reason")).toBe("unexpected");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("boom"));
+  });
+
+  it("reports a missing code without calling Supabase", async () => {
+    const res = await GET(new Request(CALLBACK));
+    const location = new URL(res.headers.get("location") ?? "");
+
+    expect(location.searchParams.get("oauth_reason")).toBe("missing_code");
+    expect(mockExchange).not.toHaveBeenCalled();
+  });
+
+  it("expires stale supabase cookies on failure so the retry starts clean", async () => {
+    mockExchange.mockResolvedValue({ data: {}, error: { message: "bad verifier" } });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+    const cookies = setCookies(res);
+
+    expect(cookies["sb-abc-auth-token-code-verifier"]).toContain("Max-Age=0");
+    expect(cookies["sb-abc-auth-token.0"]).toContain("Max-Age=0");
+    // Only Supabase's own cookies are cleared.
+    expect(cookies["radestate.session"]).toBeUndefined();
+  });
+
+  it("leaves supabase cookies alone on success", async () => {
+    mockExchange.mockResolvedValue({ data: { session: session() }, error: null });
+
+    const res = await GET(new Request(`${CALLBACK}?code=abc`));
+
+    expect(setCookies(res)["sb-abc-auth-token-code-verifier"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Symptom

On `/sign-in`, the first Google sign-in attempt fails with
"Sign-in failed. Please try again." Retrying succeeds.

## Diagnosis

That string exists in exactly one place — `frontend/app/(auth)/auth/callback/route.ts`
— and nowhere in the email/password path. So this is the Google button: Google
redirects back to `/auth/callback`, the route bails, and it bounces to
`/sign-in?oauth_error=…`, which `OAuthErrorNotice` renders. That also rules out
a backend cold start — this route talks to Supabase directly and never touches
the FastAPI API.

Two real defects turned up in the route:

1. **A silent failure branch.** `if (error || !data.session?.refresh_token)`
   collapsed two very different failures into one message, and only logged when
   `error` was set. An exchange that succeeded but returned no refresh token
   produced the user-facing error with **zero** log output — invisible in the
   Vercel function logs.
2. **Stale PKCE state survived the failure.** `@supabase/ssr` (v0.10.2,
   `flowType: "pkce"`) keeps the code verifier in an
   `sb-<ref>-auth-token-code-verifier` cookie. On failure the route left it —
   plus any half-written `-auth-token.0`/`.1` chunks — in place, so the next
   attempt ran against state that could not match its freshly minted code.

## Changes

- Split the two failure branches and log a distinct reason for each:
  `exchange_failed`, `no_refresh_token`, `unexpected`, `missing_code`.
- Echo that reason to the redirect as `oauth_reason`, so a production failure
  can be reported straight from the address bar without digging through
  function logs.
- Expire the `sb-*` cookies on every failure path so a retry starts from a clean
  slate. `radestate.session` is deliberately left alone.

## Testing

The route had **no tests at all**. Adds `frontend/tests/app/auth-callback.test.ts`
with 9 cases: success storing the session and redirecting home, `next` path
handling including rejecting `//evil.test`, each of the four failure reasons,
cookie clearing on failure but not on success, and that only Supabase's own
cookies are cleared.

Full frontend suite green: **886 tests across 114 files**. ESLint exit 0 and
`tsc --noEmit` clean on both touched files.